### PR TITLE
Add Pour symmetry and variable input coin arity

### DIFF
--- a/libzerocash/PourTransaction.cpp
+++ b/libzerocash/PourTransaction.cpp
@@ -64,6 +64,9 @@ PourTransaction::PourTransaction(uint16_t version_num,
 {
     this->version = version_num;
 
+    std::vector<unsigned char>  publicInValue(v_size);
+    uint64_t inval = 0;
+    convertIntToBytesVector(inval, publicInValue);
     convertIntToBytesVector(v_pub, this->publicValue);
 
     this->cm_1 = c_1_new.getCoinCommitment();
@@ -84,7 +87,8 @@ PourTransaction::PourTransaction(uint16_t version_num,
     std::vector<bool> nonce_old_2_bv(rho_size * 8);
     std::vector<bool> val_new_1_bv(v_size * 8);
     std::vector<bool> val_new_2_bv(v_size * 8);
-    std::vector<bool> val_pub_bv(v_size * 8);
+    std::vector<bool> val_in_pub_bv(v_size * 8);
+    std::vector<bool> val_out_pub_bv(v_size * 8);
     std::vector<bool> val_old_1_bv(v_size * 8);
     std::vector<bool> val_old_2_bv(v_size * 8);
     std::vector<bool> cm_new_1_bv(cm_size * 8);
@@ -129,7 +133,8 @@ PourTransaction::PourTransaction(uint16_t version_num,
     convertIntToBytesVector(c_2_new.getValue(), v_new_2_conv);
     libzerocash::convertBytesVectorToVector(v_new_2_conv, val_new_2_bv);
 
-    convertBytesVectorToVector(this->publicValue, val_pub_bv);
+    convertBytesVectorToVector(publicInValue, val_in_pub_bv);
+    convertBytesVectorToVector(this->publicValue, val_out_pub_bv);
 
     std::vector<bool> nonce_old_1(rho_size * 8);
     copy(nonce_old_1_bv.begin(), nonce_old_1_bv.end(), nonce_old_1.begin());
@@ -207,7 +212,8 @@ PourTransaction::PourTransaction(uint16_t version_num,
             { nonce_new_1_bv, nonce_new_2_bv },
             { nonce_old_1_bv, nonce_old_2_bv },
             { val_new_1_bv, val_new_2_bv },
-            val_pub_bv,
+            val_in_pub_bv,
+            val_out_pub_bv,
             { val_old_1_bv, val_old_2_bv },
             h_S_bv);
 
@@ -287,6 +293,10 @@ bool PourTransaction::verify(ZerocashParams& params,
 		return true;
 	}
 
+    std::vector<unsigned char>  publicInValue(v_size);
+    uint64_t inval = 0;
+    convertIntToBytesVector(inval, publicInValue);
+
     zerocash_pour_proof<ZerocashParams::zerocash_pp> proof_SNARK;
     std::stringstream ss;
     ss.str(this->zkSNARK);
@@ -305,7 +315,8 @@ bool PourTransaction::verify(ZerocashParams& params,
     std::vector<bool> sn_old_2_bv(sn_size * 8);
     std::vector<bool> cm_new_1_bv(cm_size * 8);
     std::vector<bool> cm_new_2_bv(cm_size * 8);
-    std::vector<bool> val_pub_bv(v_size * 8);
+    std::vector<bool> val_in_pub_bv(v_size * 8);
+    std::vector<bool> val_out_pub_bv(v_size * 8);
     std::vector<bool> MAC_1_bv(h_size * 8);
     std::vector<bool> MAC_2_bv(h_size * 8);
 
@@ -314,7 +325,8 @@ bool PourTransaction::verify(ZerocashParams& params,
     convertBytesVectorToVector(this->serialNumber_2, sn_old_2_bv);
     convertBytesVectorToVector(this->cm_1.getCommitmentValue(), cm_new_1_bv);
     convertBytesVectorToVector(this->cm_2.getCommitmentValue(), cm_new_2_bv);
-    convertBytesVectorToVector(this->publicValue, val_pub_bv);
+    convertBytesVectorToVector(publicInValue, val_in_pub_bv);
+    convertBytesVectorToVector(this->publicValue, val_out_pub_bv);
     convertBytesVectorToVector(this->MAC_1, MAC_1_bv);
     convertBytesVectorToVector(this->MAC_2, MAC_2_bv);
 
@@ -339,7 +351,8 @@ bool PourTransaction::verify(ZerocashParams& params,
                                                                                       root_bv,
                                                                                       { sn_old_1_bv, sn_old_2_bv },
                                                                                       { cm_new_1_bv, cm_new_2_bv },
-                                                                                      val_pub_bv,
+                                                                                      val_in_pub_bv,
+                                                                                      val_out_pub_bv,
                                                                                       h_S_bv,
                                                                                       { MAC_1_bv, MAC_2_bv },
                                                                                       proof_SNARK);

--- a/zerocash_pour_ppzksnark/tests/test_zerocash_pour_ppzksnark.cpp
+++ b/zerocash_pour_ppzksnark/tests/test_zerocash_pour_ppzksnark.cpp
@@ -146,7 +146,8 @@ void test_zerocash_pour_ppzksnark(const size_t num_old_coins, const size_t num_n
     std::vector<bit_vector> new_coin_serial_number_nonces(num_new_coins); //
     std::vector<bit_vector> old_coin_serial_number_nonces(num_old_coins); //
     std::vector<bit_vector> new_coin_values(num_new_coins); //
-    bit_vector public_value; //
+    bit_vector public_in_value; //
+    bit_vector public_out_value; //
     std::vector<bit_vector> old_coin_values(num_old_coins); //
     bit_vector signature_public_key_hash; //
 
@@ -159,7 +160,8 @@ void test_zerocash_pour_ppzksnark(const size_t num_old_coins, const size_t num_n
     std::transform(old_coin_values_as_integers.begin(), old_coin_values_as_integers.end(),
                    old_coin_values.begin(),
                    [] (const size_t value) { return int_to_bit_vector(value, coin_value_length); });
-    public_value = int_to_bit_vector(all_new_values_as_integers[0], coin_value_length);
+    public_in_value = int_to_bit_vector(0, coin_value_length);
+    public_out_value = int_to_bit_vector(all_new_values_as_integers[0], coin_value_length);
     std::transform(all_new_values_as_integers.begin() + 1, all_new_values_as_integers.end(),
                    new_coin_values.begin(),
                    [] (const size_t value) { return int_to_bit_vector(value, coin_value_length); });
@@ -268,7 +270,8 @@ void test_zerocash_pour_ppzksnark(const size_t num_old_coins, const size_t num_n
                                new_coin_serial_number_nonces,
                                old_coin_serial_number_nonces,
                                new_coin_values,
-                               public_value,
+                               public_in_value,
+                               public_out_value,
                                old_coin_values,
                                signature_public_key_hash);
     assert(pb.is_satisfied());
@@ -291,7 +294,8 @@ void test_zerocash_pour_ppzksnark(const size_t num_old_coins, const size_t num_n
                                                                          new_coin_serial_number_nonces,
                                                                          old_coin_serial_number_nonces,
                                                                          new_coin_values,
-                                                                         public_value,
+                                                                         public_in_value,
+                                                                         public_out_value,
                                                                          old_coin_values,
                                                                          signature_public_key_hash);
     proof = reserialize<zerocash_pour_proof<ppT> >(proof);
@@ -300,7 +304,8 @@ void test_zerocash_pour_ppzksnark(const size_t num_old_coins, const size_t num_n
                                                                            merkle_tree_root,
                                                                            old_coin_serial_numbers,
                                                                            new_coin_commitments,
-                                                                           public_value,
+                                                                           public_in_value,
+                                                                           public_out_value,
                                                                            signature_public_key_hash,
                                                                            signature_public_key_hash_macs,
                                                                            proof);

--- a/zerocash_pour_ppzksnark/zerocash_pour_gadget.hpp
+++ b/zerocash_pour_ppzksnark/zerocash_pour_gadget.hpp
@@ -94,7 +94,8 @@ public:
     std::shared_ptr<digest_variable<FieldT> > merkle_tree_root_variable;
     std::vector<std::shared_ptr<digest_variable<FieldT> > > old_coin_serial_number_variables;
     std::vector<std::shared_ptr<digest_variable<FieldT> > > new_coin_commitment_variables;
-    pb_variable_array<FieldT> public_value_variable;
+    pb_variable_array<FieldT> public_in_value_variable;
+    pb_variable_array<FieldT> public_out_value_variable;
     std::shared_ptr<digest_variable<FieldT> > signature_public_key_hash_variable;
     std::vector<std::shared_ptr<digest_variable<FieldT> > > mac_of_signature_public_key_hash_variables;
 
@@ -162,7 +163,8 @@ public:
                                const std::vector<bit_vector> &new_coin_serial_number_nonces,
                                const std::vector<bit_vector> &old_coin_serial_number_nonces,
                                const std::vector<bit_vector> &new_coin_values,
-                               const bit_vector &public_value,
+                               const bit_vector &public_in_value,
+                               const bit_vector &public_out_value,
                                const std::vector<bit_vector> &old_coin_values,
                                const bit_vector &signature_public_key_hash);
 };
@@ -173,7 +175,8 @@ r1cs_primary_input<FieldT> zerocash_pour_input_map(const size_t num_old_coins,
                                                    const bit_vector &merkle_tree_root,
                                                    const std::vector<bit_vector> &old_coin_serial_numbers,
                                                    const std::vector<bit_vector> &new_coin_commitments,
-                                                   const bit_vector &public_value,
+                                                   const bit_vector &public_in_value,
+                                                   const bit_vector &public_out_value,
                                                    const bit_vector &signature_public_key_hash,
                                                    const std::vector<bit_vector> &signature_public_key_hash_macs);
 

--- a/zerocash_pour_ppzksnark/zerocash_pour_gadget.hpp
+++ b/zerocash_pour_ppzksnark/zerocash_pour_gadget.hpp
@@ -93,6 +93,7 @@ public:
     /* individual components of the unpacked R1CS input */
     std::shared_ptr<digest_variable<FieldT> > merkle_tree_root_variable;
     std::vector<std::shared_ptr<digest_variable<FieldT> > > old_coin_serial_number_variables;
+    pb_variable_array<FieldT> old_coin_enforce_commitment;
     std::vector<std::shared_ptr<digest_variable<FieldT> > > new_coin_commitment_variables;
     pb_variable_array<FieldT> public_in_value_variable;
     pb_variable_array<FieldT> public_out_value_variable;

--- a/zerocash_pour_ppzksnark/zerocash_pour_gadget.tcc
+++ b/zerocash_pour_ppzksnark/zerocash_pour_gadget.tcc
@@ -27,7 +27,7 @@ zerocash_pour_gadget<FieldT>::zerocash_pour_gadget(protoboard<FieldT> &pb,
     num_new_coins(num_new_coins)
 {
     /* allocate packed inputs */
-    const size_t input_size_in_bits = sha256_digest_len + num_old_coins*sha256_digest_len + num_new_coins*sha256_digest_len + coin_value_length + (num_old_coins + 1) * sha256_digest_len;
+    const size_t input_size_in_bits = sha256_digest_len + num_old_coins*sha256_digest_len + num_new_coins*sha256_digest_len + (coin_value_length * 2) + (num_old_coins + 1) * sha256_digest_len;
     const size_t input_size_in_field_elements = div_ceil(input_size_in_bits, FieldT::capacity());
     input_as_field_elements.allocate(pb, input_size_in_field_elements, FMT(annotation_prefix, " input_as_field_elements"));
     this->pb.set_input_sizes(input_size_in_field_elements);
@@ -47,7 +47,8 @@ zerocash_pour_gadget<FieldT>::zerocash_pour_gadget(protoboard<FieldT> &pb,
         new_coin_commitment_variables[i].reset(new digest_variable<FieldT>(pb, sha256_digest_len, FMT(annotation_prefix, " new_coin_commitment_variables_%zu", i)));
     }
 
-    public_value_variable.allocate(pb, coin_value_length, FMT(annotation_prefix, " public_value_variable"));
+    public_in_value_variable.allocate(pb, coin_value_length, FMT(annotation_prefix, " public_in_value_variable"));
+    public_out_value_variable.allocate(pb, coin_value_length, FMT(annotation_prefix, " public_out_value_variable"));
     signature_public_key_hash_variable.reset(new digest_variable<FieldT>(pb, sha256_digest_len, FMT(annotation_prefix, " signature_public_key_hash")));
 
     mac_of_signature_public_key_hash_variables.resize(num_old_coins);
@@ -66,7 +67,8 @@ zerocash_pour_gadget<FieldT>::zerocash_pour_gadget(protoboard<FieldT> &pb,
     {
         input_as_bits.insert(input_as_bits.end(), new_coin_commitment_variables[i]->bits.begin(), new_coin_commitment_variables[i]->bits.end());
     }
-    input_as_bits.insert(input_as_bits.end(), public_value_variable.begin(), public_value_variable.end());
+    input_as_bits.insert(input_as_bits.end(), public_in_value_variable.begin(), public_in_value_variable.end());
+    input_as_bits.insert(input_as_bits.end(), public_out_value_variable.begin(), public_out_value_variable.end());
     input_as_bits.insert(input_as_bits.end(), signature_public_key_hash_variable->bits.begin(), signature_public_key_hash_variable->bits.end());
     for (size_t i = 0; i < num_old_coins; ++i)
     {
@@ -306,7 +308,8 @@ void zerocash_pour_gadget<FieldT>::generate_r1cs_constraints()
             generate_boolean_r1cs_constraint<FieldT>(this->pb, new_coin_value_variables[i][j], FMT(this->annotation_prefix, " new_coin_value_variables_%zu_%zu", i, j));
         }
 
-        generate_boolean_r1cs_constraint<FieldT>(this->pb, public_value_variable[j], FMT(this->annotation_prefix, " public_value_variable_%zu", j));
+        generate_boolean_r1cs_constraint<FieldT>(this->pb, public_in_value_variable[j], FMT(this->annotation_prefix, " public_in_value_variable_%zu", j));
+        generate_boolean_r1cs_constraint<FieldT>(this->pb, public_out_value_variable[j], FMT(this->annotation_prefix, " public_out_value_variable_%zu", j));
     }
 
     /* check the balance equation */
@@ -315,13 +318,14 @@ void zerocash_pour_gadget<FieldT>::generate_r1cs_constraints()
     {
         old_packed_value = old_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(old_coin_value_variables[i].rbegin(), old_coin_value_variables[i].rend()));
     }
+    old_packed_value = old_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(public_in_value_variable.rbegin(), public_in_value_variable.rend()));
 
     linear_combination<FieldT> new_packed_value;
     for (size_t i = 0; i < num_new_coins; ++i)
     {
         new_packed_value = new_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(new_coin_value_variables[i].rbegin(), new_coin_value_variables[i].rend()));
     }
-    new_packed_value = new_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(public_value_variable.rbegin(), public_value_variable.rend()));
+    new_packed_value = new_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(public_out_value_variable.rbegin(), public_out_value_variable.rend()));
 
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, old_packed_value, new_packed_value), FMT(this->annotation_prefix, " balance"));
 }
@@ -337,7 +341,8 @@ void zerocash_pour_gadget<FieldT>::generate_r1cs_witness(const std::vector<merkl
                                                          const std::vector<bit_vector> &new_coin_serial_number_nonces,
                                                          const std::vector<bit_vector> &old_coin_serial_number_nonces,
                                                          const std::vector<bit_vector> &new_coin_values,
-                                                         const bit_vector &public_value,
+                                                         const bit_vector &public_in_value,
+                                                         const bit_vector &public_out_value,
                                                          const std::vector<bit_vector> &old_coin_values,
                                                          const bit_vector &signature_public_key_hash)
 {
@@ -369,7 +374,8 @@ void zerocash_pour_gadget<FieldT>::generate_r1cs_witness(const std::vector<merkl
         old_coin_value_variables[i].fill_with_bits(this->pb, old_coin_values[i]);
     }
 
-    public_value_variable.fill_with_bits(this->pb, public_value);
+    public_in_value_variable.fill_with_bits(this->pb, public_in_value);
+    public_out_value_variable.fill_with_bits(this->pb, public_out_value);
     signature_public_key_hash_variable->generate_r1cs_witness(signature_public_key_hash);
 
     /* do the hashing */
@@ -418,7 +424,8 @@ r1cs_primary_input<FieldT> zerocash_pour_input_map(const size_t num_old_coins,
                                                    const bit_vector &merkle_tree_root,
                                                    const std::vector<bit_vector> &old_coin_serial_numbers,
                                                    const std::vector<bit_vector> &new_coin_commitments,
-                                                   const bit_vector &public_value,
+                                                   const bit_vector &public_in_value,
+                                                   const bit_vector &public_out_value,
                                                    const bit_vector &signature_public_key_hash,
                                                    const std::vector<bit_vector> &signature_public_key_hash_macs)
 {
@@ -434,7 +441,8 @@ r1cs_primary_input<FieldT> zerocash_pour_input_map(const size_t num_old_coins,
     {
         assert(new_coin_commitment.size() == coin_commitment_length);
     }
-    assert(public_value.size() == coin_value_length);
+    assert(public_in_value.size() == coin_value_length);
+    assert(public_out_value.size() == coin_value_length);
     assert(signature_public_key_hash.size() == sha256_digest_len);
     assert(signature_public_key_hash_macs.size() == num_old_coins);
     for (auto &signature_public_key_hash_mac : signature_public_key_hash_macs)
@@ -453,7 +461,8 @@ r1cs_primary_input<FieldT> zerocash_pour_input_map(const size_t num_old_coins,
     {
         input_as_bits.insert(input_as_bits.end(), new_coin_commitment.begin(), new_coin_commitment.end());
     }
-    input_as_bits.insert(input_as_bits.end(), public_value.begin(), public_value.end());
+    input_as_bits.insert(input_as_bits.end(), public_in_value.begin(), public_in_value.end());
+    input_as_bits.insert(input_as_bits.end(), public_out_value.begin(), public_out_value.end());
     input_as_bits.insert(input_as_bits.end(), signature_public_key_hash.begin(), signature_public_key_hash.end());
     for (auto &signature_public_key_hash_mac : signature_public_key_hash_macs)
     {

--- a/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.hpp
+++ b/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.hpp
@@ -205,7 +205,8 @@ zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash
                                                                   const std::vector<bit_vector> &new_coin_serial_number_nonces,
                                                                   const std::vector<bit_vector> &old_coin_serial_number_nonces,
                                                                   const std::vector<bit_vector> &new_coin_values,
-                                                                  const bit_vector &public_value,
+                                                                  const bit_vector &public_in_value,
+                                                                  const bit_vector &public_out_value,
                                                                   const std::vector<bit_vector> &old_coin_values,
                                                                   const bit_vector &signature_public_key_hash);
 
@@ -217,7 +218,8 @@ bool zerocash_pour_ppzksnark_verifier(const zerocash_pour_verification_key<ppzks
                                       const bit_vector &merkle_tree_root,
                                       const std::vector<bit_vector> &old_coin_serial_numbers,
                                       const std::vector<bit_vector> &new_coin_commitments,
-                                      const bit_vector &public_value,
+                                      const bit_vector &public_in_value,
+                                      const bit_vector &public_out_value,
                                       const bit_vector &signature_public_key_hash,
                                       const std::vector<bit_vector> &signature_public_key_hash_macs,
                                       const zerocash_pour_proof<ppzksnark_ppT> &proof);

--- a/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.tcc
+++ b/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.tcc
@@ -140,7 +140,8 @@ zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash
                                                                   const std::vector<bit_vector> &new_coin_serial_number_nonces,
                                                                   const std::vector<bit_vector> &old_coin_serial_number_nonces,
                                                                   const std::vector<bit_vector> &new_coin_values,
-                                                                  const bit_vector &public_value,
+                                                                  const bit_vector &public_in_value,
+                                                                  const bit_vector &public_out_value,
                                                                   const std::vector<bit_vector> &old_coin_values,
                                                                   const bit_vector &signature_public_key_hash)
 {
@@ -161,7 +162,8 @@ zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash
                             new_coin_serial_number_nonces,
                             old_coin_serial_number_nonces,
                             new_coin_values,
-                            public_value,
+                            public_in_value,
+                            public_out_value,
                             old_coin_values,
                             signature_public_key_hash);
     assert(pb.is_satisfied());
@@ -177,7 +179,8 @@ bool zerocash_pour_ppzksnark_verifier(const zerocash_pour_verification_key<ppzks
                                       const bit_vector &merkle_tree_root,
                                       const std::vector<bit_vector> &old_coin_serial_numbers,
                                       const std::vector<bit_vector> &new_coin_commitments,
-                                      const bit_vector &public_value,
+                                      const bit_vector &public_in_value,
+                                      const bit_vector &public_out_value,
                                       const bit_vector &signature_public_key_hash,
                                       const std::vector<bit_vector> &signature_public_key_hash_macs,
                                       const zerocash_pour_proof<ppzksnark_ppT> &proof)
@@ -190,7 +193,8 @@ bool zerocash_pour_ppzksnark_verifier(const zerocash_pour_verification_key<ppzks
                                                                              merkle_tree_root,
                                                                              old_coin_serial_numbers,
                                                                              new_coin_commitments,
-                                                                             public_value,
+                                                                             public_in_value,
+                                                                             public_out_value,
                                                                              signature_public_key_hash,
                                                                              signature_public_key_hash_macs);
     const bool ans = r1cs_ppzksnark_verifier_strong_IC<ppzksnark_ppT>(vk.r1cs_vk, input, proof);


### PR DESCRIPTION
**WIP**

This modifies the circuit to add symmetry to pours (a `vpub_in` for the balance equation) along with variable input arity to unify protects and pours.

Missing:
- complete vpub_in support for `PourTransaction`
- tests
