### PR TITLE
Add Pour symmetry and variable input coin arity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ SRCS= \
 	$(LIBZEROCASH)/CoinCommitment.cpp \
 	$(LIBZEROCASH)/Coin.cpp \
 	$(LIBZEROCASH)/MintTransaction.cpp \
+	$(LIBZEROCASH)/PourInput.cpp \
+	$(LIBZEROCASH)/PourOutput.cpp \
 	$(LIBZEROCASH)/PourTransaction.cpp \
 	$(LIBZEROCASH)/ZerocashParams.cpp \
 	$(TESTUTILS)/timer.cpp

--- a/libzerocash/PourInput.cpp
+++ b/libzerocash/PourInput.cpp
@@ -16,7 +16,9 @@
 
 namespace libzerocash {
 
-PourInput::PourInput(int tree_depth): old_coin(), old_address(), merkle_index(), path() {
+PourInput::PourInput(int tree_depth): old_coin(), merkle_index(), path() {
+	this->old_address = Address::CreateNewRandomAddress();
+
 	this->old_coin = Coin(this->old_address.getPublicAddress(), 0);
 
 	// dummy merkle tree
@@ -38,7 +40,8 @@ PourInput::PourInput(int tree_depth): old_coin(), old_address(), merkle_index(),
 PourInput::PourInput(Coin old_coin,
           Address old_address,
           size_t merkle_index,
-          merkle_authentication_path path) : old_coin(old_coin), old_address(old_address), merkle_index(merkle_index), path(path) {
+          merkle_authentication_path path) : old_coin(old_coin), merkle_index(merkle_index), path(path) {
+		this->old_address = old_address;
 };
 
 } /* namespace libzerocash */

--- a/libzerocash/PourInput.cpp
+++ b/libzerocash/PourInput.cpp
@@ -23,7 +23,7 @@ PourInput::PourInput(int tree_depth): old_coin(), old_address(), merkle_index(),
 	IncrementalMerkleTree merkleTree(tree_depth);
 
 	// commitment from coin
-	std::vector<bool> commitment(cm_size * 8);
+	std::vector<bool> commitment(ZC_CM_SIZE * 8);
 	convertBytesVectorToVector(this->old_coin.getCoinCommitment().getCommitmentValue(), commitment);
 
 	// insert commitment into the merkle tree

--- a/libzerocash/PourInput.cpp
+++ b/libzerocash/PourInput.cpp
@@ -1,0 +1,44 @@
+/** @file
+ *****************************************************************************
+
+ Implementation of interfaces for the class PourInput.
+
+ See PourInput.h .
+
+ *****************************************************************************
+ * @author     This file is part of libzerocash, developed by the Zerocash
+ *             project and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+
+#include "IncrementalMerkleTree.h"
+#include "PourInput.h"
+
+namespace libzerocash {
+
+PourInput::PourInput(int tree_depth): old_coin(), old_address(), merkle_index(), path() {
+	this->old_coin = Coin(this->old_address.getPublicAddress(), 0);
+
+	// dummy merkle tree
+	IncrementalMerkleTree merkleTree(tree_depth);
+
+	// commitment from coin
+	std::vector<bool> commitment(cm_size * 8);
+	convertBytesVectorToVector(this->old_coin.getCoinCommitment().getCommitmentValue(), commitment);
+
+	// insert commitment into the merkle tree
+	std::vector<bool> index;
+	merkleTree.insertElement(commitment, index);
+
+	merkleTree.getWitness(index, this->path);
+
+	this->merkle_index = 1;
+}
+
+PourInput::PourInput(Coin old_coin,
+          Address old_address,
+          size_t merkle_index,
+          merkle_authentication_path path) : old_coin(old_coin), old_address(old_address), merkle_index(merkle_index), path(path) {
+};
+
+} /* namespace libzerocash */

--- a/libzerocash/PourInput.h
+++ b/libzerocash/PourInput.h
@@ -1,0 +1,37 @@
+/** @file
+ *****************************************************************************
+
+ Declaration of interfaces for the class PourInput.
+
+ *****************************************************************************
+ * @author     This file is part of libzerocash, developed by the Zerocash
+ *             project and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+
+#ifndef POURINPUT_H_
+#define POURINPUT_H_
+
+#include "Coin.h"
+#include "ZerocashParams.h"
+
+namespace libzerocash {
+
+class PourInput {
+public:
+    PourInput(int tree_depth);
+
+    PourInput(Coin old_coin,
+              Address old_address,
+              size_t merkle_index,
+              merkle_authentication_path path);
+
+    Coin old_coin;
+    Address old_address;
+    size_t merkle_index;
+    merkle_authentication_path path;
+};
+
+} /* namespace libzerocash */
+
+#endif /* POURINPUT_H_ */

--- a/libzerocash/PourOutput.cpp
+++ b/libzerocash/PourOutput.cpp
@@ -16,7 +16,7 @@
 namespace libzerocash {
 
 PourOutput::PourOutput(uint64_t val) {
-	Address dummy_to_address;
+	Address dummy_to_address = Address::CreateNewRandomAddress();
 
 	this->to_address = dummy_to_address.getPublicAddress();
 	this->new_coin = Coin(dummy_to_address.getPublicAddress(), val);

--- a/libzerocash/PourOutput.cpp
+++ b/libzerocash/PourOutput.cpp
@@ -15,14 +15,6 @@
 
 namespace libzerocash {
 
-PourOutput::PourOutput() {
-	Address dummy_to_address;
-
-	this->to_address = dummy_to_address.getPublicAddress();
-	this->new_coin = Coin(dummy_to_address.getPublicAddress(), 0);
-}
-
-// TODO: this is a generalization of the other constructor
 PourOutput::PourOutput(uint64_t val) {
 	Address dummy_to_address;
 

--- a/libzerocash/PourOutput.cpp
+++ b/libzerocash/PourOutput.cpp
@@ -1,0 +1,37 @@
+/** @file
+ *****************************************************************************
+
+ Implementation of interfaces for the class PourOutput.
+
+ See PourOutput.h .
+
+ *****************************************************************************
+ * @author     This file is part of libzerocash, developed by the Zerocash
+ *             project and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+
+#include "PourOutput.h"
+
+namespace libzerocash {
+
+PourOutput::PourOutput() {
+	Address dummy_to_address;
+
+	this->to_address = dummy_to_address.getPublicAddress();
+	this->new_coin = Coin(dummy_to_address.getPublicAddress(), 0);
+}
+
+// TODO: this is a generalization of the other constructor
+PourOutput::PourOutput(uint64_t val) {
+	Address dummy_to_address;
+
+	this->to_address = dummy_to_address.getPublicAddress();
+	this->new_coin = Coin(dummy_to_address.getPublicAddress(), val);
+}
+
+PourOutput::PourOutput(const Coin new_coin,
+          const PublicAddress to_address) : new_coin(new_coin), to_address(to_address) {
+}
+
+} /* namespace libzerocash */

--- a/libzerocash/PourOutput.h
+++ b/libzerocash/PourOutput.h
@@ -1,0 +1,33 @@
+/** @file
+ *****************************************************************************
+
+ Declaration of interfaces for the class PourOutput.
+
+ *****************************************************************************
+ * @author     This file is part of libzerocash, developed by the Zerocash
+ *             project and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+
+#ifndef POUROUTPUT_H_
+#define POUROUTPUT_H_
+
+#include "Coin.h"
+#include "ZerocashParams.h"
+
+namespace libzerocash {
+
+class PourOutput {
+public:
+	PourOutput();
+	PourOutput(uint64_t val);
+    PourOutput(const Coin new_coin,
+              const PublicAddress to_address);
+
+    Coin new_coin;
+    PublicAddress to_address;
+};
+
+} /* namespace libzerocash */
+
+#endif /* POUROUTPUT_H_ */

--- a/libzerocash/PourOutput.h
+++ b/libzerocash/PourOutput.h
@@ -19,7 +19,6 @@ namespace libzerocash {
 
 class PourOutput {
 public:
-	PourOutput();
 	PourOutput(uint64_t val);
     PourOutput(const Coin new_coin,
               const PublicAddress to_address);

--- a/libzerocash/PourTransaction.cpp
+++ b/libzerocash/PourTransaction.cpp
@@ -50,10 +50,10 @@ PourTransaction::PourTransaction(ZerocashParams& params,
                                  const MerkleRootType& rt,
                                  std::vector<PourInput> inputs,
                                  std::vector<PourOutput> outputs,
-                                 uint64_t vpub_in,
-                                 uint64_t vpub_out
+                                 uint64_t vpub_old,
+                                 uint64_t vpub_new
                                 ) :
-    publicInValue(ZC_V_SIZE), publicOutValue(ZC_V_SIZE), serialNumber_1(ZC_SN_SIZE), serialNumber_2(ZC_SN_SIZE), MAC_1(ZC_H_SIZE), MAC_2(ZC_H_SIZE)
+    publicOldValue(ZC_V_SIZE), publicNewValue(ZC_V_SIZE), serialNumber_1(ZC_SN_SIZE), serialNumber_2(ZC_SN_SIZE), MAC_1(ZC_H_SIZE), MAC_2(ZC_H_SIZE)
 {
     if (inputs.size() > 2 || outputs.size() > 2) {
         throw std::length_error("Too many inputs or outputs specified");
@@ -82,8 +82,8 @@ PourTransaction::PourTransaction(ZerocashParams& params,
          inputs[1].path,
          outputs[0].to_address,
          outputs[1].to_address,
-         vpub_in,
-         vpub_out,
+         vpub_old,
+         vpub_new,
          pubkeyHash,
          outputs[0].new_coin,
          outputs[1].new_coin);
@@ -102,15 +102,15 @@ PourTransaction::PourTransaction(uint16_t version_num,
                                  const merkle_authentication_path& patMAC_2,
                                  const PublicAddress& addr_1_new,
                                  const PublicAddress& addr_2_new,
-                                 uint64_t v_pub_in,
-                                 uint64_t v_pub_out,
+                                 uint64_t v_pub_old,
+                                 uint64_t v_pub_new,
                                  const std::vector<unsigned char>& pubkeyHash,
                                  const Coin& c_1_new,
                                  const Coin& c_2_new) :
-    publicInValue(ZC_V_SIZE), publicOutValue(ZC_V_SIZE), serialNumber_1(ZC_SN_SIZE), serialNumber_2(ZC_SN_SIZE), MAC_1(ZC_H_SIZE), MAC_2(ZC_H_SIZE)
+    publicOldValue(ZC_V_SIZE), publicNewValue(ZC_V_SIZE), serialNumber_1(ZC_SN_SIZE), serialNumber_2(ZC_SN_SIZE), MAC_1(ZC_H_SIZE), MAC_2(ZC_H_SIZE)
 {
     init(version_num, params, rt, c_1_old, c_2_old, addr_1_old, addr_2_old, patMerkleIdx_1, patMerkleIdx_2,
-         patMAC_1, patMAC_2, addr_1_new, addr_2_new, v_pub_in, v_pub_out, pubkeyHash, c_1_new, c_2_new);
+         patMAC_1, patMAC_2, addr_1_new, addr_2_new, v_pub_old, v_pub_new, pubkeyHash, c_1_new, c_2_new);
 }
 
 void PourTransaction::init(uint16_t version_num,
@@ -126,16 +126,16 @@ void PourTransaction::init(uint16_t version_num,
                      const merkle_authentication_path& patMAC_2,
                      const PublicAddress& addr_1_new,
                      const PublicAddress& addr_2_new,
-                     uint64_t v_pub_in,
-                     uint64_t v_pub_out,
+                     uint64_t v_pub_old,
+                     uint64_t v_pub_new,
                      const std::vector<unsigned char>& pubkeyHash,
                      const Coin& c_1_new,
                      const Coin& c_2_new)
 {
     this->version = version_num;
 
-    convertIntToBytesVector(v_pub_in, this->publicInValue);
-    convertIntToBytesVector(v_pub_out, this->publicOutValue);
+    convertIntToBytesVector(v_pub_old, this->publicOldValue);
+    convertIntToBytesVector(v_pub_new, this->publicNewValue);
 
     this->cm_1 = c_1_new.getCoinCommitment();
     this->cm_2 = c_2_new.getCoinCommitment();
@@ -155,8 +155,8 @@ void PourTransaction::init(uint16_t version_num,
     std::vector<bool> nonce_old_2_bv(ZC_RHO_SIZE * 8);
     std::vector<bool> val_new_1_bv(ZC_V_SIZE * 8);
     std::vector<bool> val_new_2_bv(ZC_V_SIZE * 8);
-    std::vector<bool> val_in_pub_bv(ZC_V_SIZE * 8);
-    std::vector<bool> val_out_pub_bv(ZC_V_SIZE * 8);
+    std::vector<bool> val_old_pub_bv(ZC_V_SIZE * 8);
+    std::vector<bool> val_new_pub_bv(ZC_V_SIZE * 8);
     std::vector<bool> val_old_1_bv(ZC_V_SIZE * 8);
     std::vector<bool> val_old_2_bv(ZC_V_SIZE * 8);
     std::vector<bool> cm_new_1_bv(ZC_CM_SIZE * 8);
@@ -201,8 +201,8 @@ void PourTransaction::init(uint16_t version_num,
     convertIntToBytesVector(c_2_new.getValue(), v_new_2_conv);
     libzerocash::convertBytesVectorToVector(v_new_2_conv, val_new_2_bv);
 
-    convertBytesVectorToVector(this->publicInValue, val_in_pub_bv);
-    convertBytesVectorToVector(this->publicOutValue, val_out_pub_bv);
+    convertBytesVectorToVector(this->publicOldValue, val_old_pub_bv);
+    convertBytesVectorToVector(this->publicNewValue, val_new_pub_bv);
 
     std::vector<bool> nonce_old_1(ZC_RHO_SIZE * 8);
     copy(nonce_old_1_bv.begin(), nonce_old_1_bv.end(), nonce_old_1.begin());
@@ -280,8 +280,8 @@ void PourTransaction::init(uint16_t version_num,
             { nonce_new_1_bv, nonce_new_2_bv },
             { nonce_old_1_bv, nonce_old_2_bv },
             { val_new_1_bv, val_new_2_bv },
-            val_in_pub_bv,
-            val_out_pub_bv,
+            val_old_pub_bv,
+            val_new_pub_bv,
             { val_old_1_bv, val_old_2_bv },
             h_S_bv);
 
@@ -370,8 +370,8 @@ bool PourTransaction::verify(ZerocashParams& params,
 	if (pubkeyHash.size() != ZC_H_SIZE)	{ return false; }
 	if (this->serialNumber_1.size() != ZC_SN_SIZE)	{ return false; }
 	if (this->serialNumber_2.size() != ZC_SN_SIZE)	{ return false; }
-	if (this->publicInValue.size() != ZC_V_SIZE) { return false; }
-	if (this->publicOutValue.size() != ZC_V_SIZE) { return false; }
+	if (this->publicOldValue.size() != ZC_V_SIZE) { return false; }
+	if (this->publicNewValue.size() != ZC_V_SIZE) { return false; }
 	if (this->MAC_1.size() != ZC_H_SIZE)	{ return false; }
 	if (this->MAC_2.size() != ZC_H_SIZE)	{ return false; }
 
@@ -380,8 +380,8 @@ bool PourTransaction::verify(ZerocashParams& params,
     std::vector<bool> sn_old_2_bv(ZC_SN_SIZE * 8);
     std::vector<bool> cm_new_1_bv(ZC_CM_SIZE * 8);
     std::vector<bool> cm_new_2_bv(ZC_CM_SIZE * 8);
-    std::vector<bool> val_in_pub_bv(ZC_V_SIZE * 8);
-    std::vector<bool> val_out_pub_bv(ZC_V_SIZE * 8);
+    std::vector<bool> val_old_pub_bv(ZC_V_SIZE * 8);
+    std::vector<bool> val_new_pub_bv(ZC_V_SIZE * 8);
     std::vector<bool> MAC_1_bv(ZC_H_SIZE * 8);
     std::vector<bool> MAC_2_bv(ZC_H_SIZE * 8);
 
@@ -390,8 +390,8 @@ bool PourTransaction::verify(ZerocashParams& params,
     convertBytesVectorToVector(this->serialNumber_2, sn_old_2_bv);
     convertBytesVectorToVector(this->cm_1.getCommitmentValue(), cm_new_1_bv);
     convertBytesVectorToVector(this->cm_2.getCommitmentValue(), cm_new_2_bv);
-    convertBytesVectorToVector(this->publicInValue, val_in_pub_bv);
-    convertBytesVectorToVector(this->publicOutValue, val_out_pub_bv);
+    convertBytesVectorToVector(this->publicOldValue, val_old_pub_bv);
+    convertBytesVectorToVector(this->publicNewValue, val_new_pub_bv);
     convertBytesVectorToVector(this->MAC_1, MAC_1_bv);
     convertBytesVectorToVector(this->MAC_2, MAC_2_bv);
 
@@ -416,8 +416,8 @@ bool PourTransaction::verify(ZerocashParams& params,
                                                                                       root_bv,
                                                                                       { sn_old_1_bv, sn_old_2_bv },
                                                                                       { cm_new_1_bv, cm_new_2_bv },
-                                                                                      val_in_pub_bv,
-                                                                                      val_out_pub_bv,
+                                                                                      val_old_pub_bv,
+                                                                                      val_new_pub_bv,
                                                                                       h_S_bv,
                                                                                       { MAC_1_bv, MAC_2_bv },
                                                                                       proof_SNARK);
@@ -456,11 +456,11 @@ const CoinCommitmentValue& PourTransaction::getNewCoinCommitmentValue2() const{
 }
 
 uint64_t PourTransaction::getPublicValueIn() const{
-    return convertBytesVectorToInt(this->publicInValue);
+    return convertBytesVectorToInt(this->publicOldValue);
 }
 
 uint64_t PourTransaction::getPublicValueOut() const{
-	return convertBytesVectorToInt(this->publicOutValue);
+	return convertBytesVectorToInt(this->publicNewValue);
 }
 
 } /* namespace libzerocash */

--- a/libzerocash/PourTransaction.cpp
+++ b/libzerocash/PourTransaction.cpp
@@ -55,8 +55,8 @@ PourTransaction::PourTransaction(ZerocashParams& params,
                                 ) :
     publicInValue(v_size), publicOutValue(v_size), serialNumber_1(sn_size), serialNumber_2(sn_size), MAC_1(h_size), MAC_2(h_size)
 {
-    if (inputs.size() <= 2 || outputs.size() <= 2) {
-        throw "PourTransaction provided with too many inputs or outputs";
+    if (inputs.size() > 2 || outputs.size() > 2) {
+        throw std::length_error("Too many inputs or outputs specified");
     }
     
     while (inputs.size() < 2) {

--- a/libzerocash/PourTransaction.cpp
+++ b/libzerocash/PourTransaction.cpp
@@ -53,7 +53,7 @@ PourTransaction::PourTransaction(ZerocashParams& params,
                                  uint64_t vpub_in,
                                  uint64_t vpub_out
                                 ) :
-    publicInValue(v_size), publicOutValue(v_size), serialNumber_1(sn_size), serialNumber_2(sn_size), MAC_1(h_size), MAC_2(h_size)
+    publicInValue(ZC_V_SIZE), publicOutValue(ZC_V_SIZE), serialNumber_1(ZC_SN_SIZE), serialNumber_2(ZC_SN_SIZE), MAC_1(ZC_H_SIZE), MAC_2(ZC_H_SIZE)
 {
     if (inputs.size() > 2 || outputs.size() > 2) {
         throw std::length_error("Too many inputs or outputs specified");

--- a/libzerocash/PourTransaction.cpp
+++ b/libzerocash/PourTransaction.cpp
@@ -470,17 +470,11 @@ const CoinCommitmentValue& PourTransaction::getNewCoinCommitmentValue2() const{
 	return this->cm_2.getCommitmentValue();
 }
 
-/**
- * Returns the amount of money this transaction converts back into basecoin.
- */
-uint64_t PourTransaction::getMonetaryValueIn() const{
+uint64_t PourTransaction::getPublicValueIn() const{
     return convertBytesVectorToInt(this->publicInValue);
 }
 
-/**
- * Returns the amount of money this transaction converts back into basecoin.
- */
-uint64_t PourTransaction::getMonetaryValueOut() const{
+uint64_t PourTransaction::getPublicValueOut() const{
 	return convertBytesVectorToInt(this->publicOutValue);
 }
 

--- a/libzerocash/PourTransaction.cpp
+++ b/libzerocash/PourTransaction.cpp
@@ -55,8 +55,9 @@ PourTransaction::PourTransaction(ZerocashParams& params,
                                 ) :
     publicInValue(v_size), publicOutValue(v_size), serialNumber_1(sn_size), serialNumber_2(sn_size), MAC_1(h_size), MAC_2(h_size)
 {
-    assert(inputs.size() <= 2);
-    assert(outputs.size() <= 2);
+    if (inputs.size() <= 2 || outputs.size() <= 2) {
+        throw "PourTransaction provided with too many inputs or outputs";
+    }
     
     while (inputs.size() < 2) {
         // Push a dummy input of value 0.
@@ -65,11 +66,8 @@ PourTransaction::PourTransaction(ZerocashParams& params,
 
     while (outputs.size() < 2) {
         // Push a dummy output of value 0.
-        outputs.push_back(PourOutput());
+        outputs.push_back(PourOutput(0));
     }
-
-    assert(inputs.size() == 2);
-    assert(outputs.size() == 2);
 
     init(1,
          params,

--- a/libzerocash/PourTransaction.cpp
+++ b/libzerocash/PourTransaction.cpp
@@ -64,6 +64,9 @@ PourTransaction::PourTransaction(uint16_t version_num,
 {
     this->version = version_num;
 
+    std::vector<unsigned char>  publicInValue(v_size);
+    uint64_t inval = 0;
+    convertIntToBytesVector(inval, publicInValue);
     convertIntToBytesVector(v_pub, this->publicValue);
 
     this->cm_1 = c_1_new.getCoinCommitment();
@@ -84,7 +87,8 @@ PourTransaction::PourTransaction(uint16_t version_num,
     std::vector<bool> nonce_old_2_bv(ZC_RHO_SIZE * 8);
     std::vector<bool> val_new_1_bv(ZC_V_SIZE * 8);
     std::vector<bool> val_new_2_bv(ZC_V_SIZE * 8);
-    std::vector<bool> val_pub_bv(ZC_V_SIZE * 8);
+    std::vector<bool> val_in_pub_bv(ZC_V_SIZE * 8);
+    std::vector<bool> val_out_pub_bv(ZC_V_SIZE * 8);
     std::vector<bool> val_old_1_bv(ZC_V_SIZE * 8);
     std::vector<bool> val_old_2_bv(ZC_V_SIZE * 8);
     std::vector<bool> cm_new_1_bv(ZC_CM_SIZE * 8);
@@ -129,7 +133,8 @@ PourTransaction::PourTransaction(uint16_t version_num,
     convertIntToBytesVector(c_2_new.getValue(), v_new_2_conv);
     libzerocash::convertBytesVectorToVector(v_new_2_conv, val_new_2_bv);
 
-    convertBytesVectorToVector(this->publicValue, val_pub_bv);
+    convertBytesVectorToVector(publicInValue, val_in_pub_bv);
+    convertBytesVectorToVector(this->publicValue, val_out_pub_bv);
 
     std::vector<bool> nonce_old_1(ZC_RHO_SIZE * 8);
     copy(nonce_old_1_bv.begin(), nonce_old_1_bv.end(), nonce_old_1.begin());
@@ -207,7 +212,8 @@ PourTransaction::PourTransaction(uint16_t version_num,
             { nonce_new_1_bv, nonce_new_2_bv },
             { nonce_old_1_bv, nonce_old_2_bv },
             { val_new_1_bv, val_new_2_bv },
-            val_pub_bv,
+            val_in_pub_bv,
+            val_out_pub_bv,
             { val_old_1_bv, val_old_2_bv },
             h_S_bv);
 
@@ -287,6 +293,10 @@ bool PourTransaction::verify(ZerocashParams& params,
 		return true;
 	}
 
+    std::vector<unsigned char>  publicInValue(v_size);
+    uint64_t inval = 0;
+    convertIntToBytesVector(inval, publicInValue);
+
     zerocash_pour_proof<ZerocashParams::zerocash_pp> proof_SNARK;
     std::stringstream ss;
     ss.str(this->zkSNARK);
@@ -305,7 +315,8 @@ bool PourTransaction::verify(ZerocashParams& params,
     std::vector<bool> sn_old_2_bv(ZC_SN_SIZE * 8);
     std::vector<bool> cm_new_1_bv(ZC_CM_SIZE * 8);
     std::vector<bool> cm_new_2_bv(ZC_CM_SIZE * 8);
-    std::vector<bool> val_pub_bv(ZC_V_SIZE * 8);
+    std::vector<bool> val_in_pub_bv(ZC_V_SIZE * 8);
+    std::vector<bool> val_out_pub_bv(ZC_V_SIZE * 8);
     std::vector<bool> MAC_1_bv(ZC_H_SIZE * 8);
     std::vector<bool> MAC_2_bv(ZC_H_SIZE * 8);
 
@@ -314,7 +325,8 @@ bool PourTransaction::verify(ZerocashParams& params,
     convertBytesVectorToVector(this->serialNumber_2, sn_old_2_bv);
     convertBytesVectorToVector(this->cm_1.getCommitmentValue(), cm_new_1_bv);
     convertBytesVectorToVector(this->cm_2.getCommitmentValue(), cm_new_2_bv);
-    convertBytesVectorToVector(this->publicValue, val_pub_bv);
+    convertBytesVectorToVector(publicInValue, val_in_pub_bv);
+    convertBytesVectorToVector(this->publicValue, val_out_pub_bv);
     convertBytesVectorToVector(this->MAC_1, MAC_1_bv);
     convertBytesVectorToVector(this->MAC_2, MAC_2_bv);
 
@@ -339,7 +351,8 @@ bool PourTransaction::verify(ZerocashParams& params,
                                                                                       root_bv,
                                                                                       { sn_old_1_bv, sn_old_2_bv },
                                                                                       { cm_new_1_bv, cm_new_2_bv },
-                                                                                      val_pub_bv,
+                                                                                      val_in_pub_bv,
+                                                                                      val_out_pub_bv,
                                                                                       h_S_bv,
                                                                                       { MAC_1_bv, MAC_2_bv },
                                                                                       proof_SNARK);

--- a/libzerocash/PourTransaction.cpp
+++ b/libzerocash/PourTransaction.cpp
@@ -58,18 +58,14 @@ PourTransaction::PourTransaction(ZerocashParams& params,
     assert(inputs.size() <= 2);
     assert(outputs.size() <= 2);
     
-    {
-        while (inputs.size() < 2) {
-            // Push a dummy input of value 0.
-            inputs.push_back(PourInput(params.getTreeDepth()));
-        }
+    while (inputs.size() < 2) {
+        // Push a dummy input of value 0.
+        inputs.push_back(PourInput(params.getTreeDepth()));
     }
 
-    {
-        while (outputs.size() < 2) {
-            // Push a dummy output of value 0.
-            outputs.push_back(PourOutput());
-        }
+    while (outputs.size() < 2) {
+        // Push a dummy output of value 0.
+        outputs.push_back(PourOutput());
     }
 
     assert(inputs.size() == 2);

--- a/libzerocash/PourTransaction.cpp
+++ b/libzerocash/PourTransaction.cpp
@@ -287,14 +287,10 @@ void PourTransaction::init(uint16_t version_num,
             { val_old_1_bv, val_old_2_bv },
             h_S_bv);
 
-        if (!proofObj) {
-            this->zkSNARK = std::string("fail");
-        } else {
-            std::stringstream ss;
-            ss << (*proofObj);
-            this->zkSNARK = ss.str();
-        }
-    }else{
+        std::stringstream ss;
+        ss << proofObj;
+        this->zkSNARK = ss.str();
+    } else {
  	   this->zkSNARK = std::string(1235,'A');
     }
 
@@ -366,11 +362,6 @@ bool PourTransaction::verify(ZerocashParams& params,
 	if(this->version == 0){
 		return true;
 	}
-
-    // FIXME
-    if (this->zkSNARK == "fail") {
-        return false;
-    }
 
     zerocash_pour_proof<ZerocashParams::zerocash_pp> proof_SNARK;
     std::stringstream ss;

--- a/libzerocash/PourTransaction.h
+++ b/libzerocash/PourTransaction.h
@@ -18,6 +18,7 @@
 #include "Zerocash.h"
 #include "PourInput.h"
 #include "PourOutput.h"
+#include <stdexcept>
 
 typedef std::vector<unsigned char> CoinCommitmentValue;
 

--- a/libzerocash/PourTransaction.h
+++ b/libzerocash/PourTransaction.h
@@ -126,19 +126,9 @@ public:
      */
     const CoinCommitmentValue& getNewCoinCommitmentValue2() const;
 
-    /**
-     * Returns the amount of money this transaction wishes to convert from basecoin.
-     *
-     * @return the value
-     */
-    uint64_t getMonetaryValueIn() const;
+    uint64_t getPublicValueIn() const;
 
-    /**
-     * Returns the amount of money this transaction wishes to convert back into basecoin.
-     *
-     * @return the value
-     */
-    uint64_t getMonetaryValueOut() const;
+    uint64_t getPublicValueOut() const;
 
     ADD_SERIALIZE_METHODS;
 

--- a/libzerocash/PourTransaction.h
+++ b/libzerocash/PourTransaction.h
@@ -34,8 +34,8 @@ public:
                                  const MerkleRootType& rt,
                                  const std::vector<PourInput> inputs,
                                  const std::vector<PourOutput> outputs,
-                                 uint64_t vpub_in,
-                                 uint64_t vpub_out
+                                 uint64_t vpub_old,
+                                 uint64_t vpub_new
                                 );
     /**
      * Generates a transaction pouring the funds  in  two existing coins into two new coins and optionally
@@ -136,8 +136,8 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(version);
-        READWRITE(publicInValue);
-        READWRITE(publicOutValue);
+        READWRITE(publicOldValue);
+        READWRITE(publicNewValue);
         READWRITE(serialNumber_1);
         READWRITE(serialNumber_2);
         READWRITE(cm_1);
@@ -152,8 +152,8 @@ public:
 
 private:
 
-    std::vector<unsigned char>  publicInValue;      // public input value of the Pour transaction
-    std::vector<unsigned char>  publicOutValue;     // public output value of the Pour transaction
+    std::vector<unsigned char>  publicOldValue;      // public input value of the Pour transaction
+    std::vector<unsigned char>  publicNewValue;     // public output value of the Pour transaction
     std::vector<unsigned char>  serialNumber_1;     // serial number of input (old) coin #1
     std::vector<unsigned char>  serialNumber_2;     // serial number of input (old) coin #1
     CoinCommitment              cm_1;               // coin commitment for output coin #1

--- a/libzerocash/PourTransaction.h
+++ b/libzerocash/PourTransaction.h
@@ -16,6 +16,8 @@
 #include "Coin.h"
 #include "ZerocashParams.h"
 #include "Zerocash.h"
+#include "PourInput.h"
+#include "PourOutput.h"
 
 typedef std::vector<unsigned char> CoinCommitmentValue;
 
@@ -26,6 +28,14 @@ namespace libzerocash {
 class PourTransaction {
 public:
     PourTransaction();
+    PourTransaction(ZerocashParams& params,
+                                 const std::vector<unsigned char>& pubkeyHash,
+                                 const MerkleRootType& rt,
+                                 const std::vector<PourInput> inputs,
+                                 const std::vector<PourOutput> outputs,
+                                 uint64_t vpub_in,
+                                 uint64_t vpub_out
+                                );
     /**
      * Generates a transaction pouring the funds  in  two existing coins into two new coins and optionally
      * converting some of those funds back into the base currency.
@@ -65,6 +75,25 @@ public:
                     const std::vector<unsigned char>& pubkeyHash,
                     const Coin& c_1_new,
                     const Coin& c_2_new);
+
+    void init(uint16_t version_num,
+                ZerocashParams& params,
+                const MerkleRootType& roott,
+                const Coin& c_1_old,
+                const Coin& c_2_old,
+                const Address& addr_1_old,
+                const Address& addr_2_old,
+                const size_t patMerkleIdx_1,
+                const size_t patMerkleIdx_2,
+                const merkle_authentication_path& path_1,
+                const merkle_authentication_path& path_2,
+                const PublicAddress& addr_1_new,
+                const PublicAddress& addr_2_new,
+                uint64_t v_pub_in,
+                uint64_t v_pub_out,
+                const std::vector<unsigned char>& pubkeyHash,
+                const Coin& c_1_new,
+                const Coin& c_2_new);
 
     /**
      * Verifies the pour transaction.

--- a/libzerocash/PourTransaction.h
+++ b/libzerocash/PourTransaction.h
@@ -60,7 +60,8 @@ public:
                     const merkle_authentication_path& path_2,
                     const PublicAddress& addr_1_new,
                     const PublicAddress& addr_2_new,
-                    uint64_t v_pub,
+                    uint64_t v_pub_in,
+                    uint64_t v_pub_out,
                     const std::vector<unsigned char>& pubkeyHash,
                     const Coin& c_1_new,
                     const Coin& c_2_new);
@@ -97,6 +98,13 @@ public:
     const CoinCommitmentValue& getNewCoinCommitmentValue2() const;
 
     /**
+     * Returns the amount of money this transaction wishes to convert from basecoin.
+     *
+     * @return the value
+     */
+    uint64_t getMonetaryValueIn() const;
+
+    /**
      * Returns the amount of money this transaction wishes to convert back into basecoin.
      *
      * @return the value
@@ -108,7 +116,8 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(version);
-        READWRITE(publicValue);
+        READWRITE(publicInValue);
+        READWRITE(publicOutValue);
         READWRITE(serialNumber_1);
         READWRITE(serialNumber_2);
         READWRITE(cm_1);
@@ -123,7 +132,8 @@ public:
 
 private:
 
-    std::vector<unsigned char>  publicValue;        // public output value of the Pour transaction
+    std::vector<unsigned char>  publicInValue;      // public input value of the Pour transaction
+    std::vector<unsigned char>  publicOutValue;     // public output value of the Pour transaction
     std::vector<unsigned char>  serialNumber_1;     // serial number of input (old) coin #1
     std::vector<unsigned char>  serialNumber_2;     // serial number of input (old) coin #1
     CoinCommitment              cm_1;               // coin commitment for output coin #1

--- a/libzerocash/ZerocashParams.cpp
+++ b/libzerocash/ZerocashParams.cpp
@@ -26,6 +26,11 @@ static void throw_missing_param_file_exception(std::string paramtype, std::strin
 
 namespace libzerocash {
 
+int ZerocashParams::getTreeDepth()
+{
+    return treeDepth;
+}
+
 zerocash_pour_keypair<ZerocashParams::zerocash_pp> ZerocashParams::GenerateNewKeyPair(const unsigned int tree_depth)
 {
     libzerocash::ZerocashParams::zerocash_pp::init_public_params();

--- a/libzerocash/ZerocashParams.h
+++ b/libzerocash/ZerocashParams.h
@@ -37,6 +37,7 @@ public:
 
     const zerocash_pour_proving_key<zerocash_pp>& getProvingKey();
     const zerocash_pour_verification_key<zerocash_pp>& getVerificationKey();
+    int getTreeDepth();
     ~ZerocashParams();
 
     static const size_t numPourInputs = 2;

--- a/libzerocash/utils/util.cpp
+++ b/libzerocash/utils/util.cpp
@@ -154,6 +154,17 @@ void convertIntToVector(uint64_t val, std::vector<bool>& v)
     }
 }
 
+uint64_t convertVectorToInt(const std::vector<bool>& v) {
+    uint64_t result = 0;
+    for (size_t i=0; i<v.size();i++) {
+        if (v.at(i)) {
+            result |= 1 << ((v.size() - 1) - i);
+        }
+    }
+
+    return result;
+}
+
 uint64_t convertBytesVectorToInt(const std::vector<unsigned char>& bytes) {
     uint64_t val_int = 0;
 

--- a/libzerocash/utils/util.cpp
+++ b/libzerocash/utils/util.cpp
@@ -162,7 +162,7 @@ uint64_t convertVectorToInt(const std::vector<bool>& v) {
     uint64_t result = 0;
     for (size_t i=0; i<v.size();i++) {
         if (v.at(i)) {
-            result |= 1 << ((v.size() - 1) - i);
+            result |= (uint64_t)1 << ((v.size() - 1) - i);
         }
     }
 

--- a/libzerocash/utils/util.cpp
+++ b/libzerocash/utils/util.cpp
@@ -155,6 +155,10 @@ void convertIntToVector(uint64_t val, std::vector<bool>& v)
 }
 
 uint64_t convertVectorToInt(const std::vector<bool>& v) {
+    if (v.size() > 64) {
+        throw std::length_error ("boolean vector must be smaller than 64 bits");
+    }
+
     uint64_t result = 0;
     for (size_t i=0; i<v.size();i++) {
         if (v.at(i)) {

--- a/libzerocash/utils/util.cpp
+++ b/libzerocash/utils/util.cpp
@@ -156,7 +156,7 @@ void convertIntToVector(uint64_t val, std::vector<bool>& v)
 
 uint64_t convertVectorToInt(const std::vector<bool>& v) {
     if (v.size() > 64) {
-        throw std::length_error ("boolean vector must be smaller than 64 bits");
+        throw std::length_error ("boolean vector can't be larger than 64 bits");
     }
 
     uint64_t result = 0;

--- a/libzerocash/utils/util.h
+++ b/libzerocash/utils/util.h
@@ -45,6 +45,8 @@ void convertIntToBytesVector(const uint64_t val_int, std::vector<unsigned char>&
 
 void convertIntToVector(uint64_t val, std::vector<bool>& v);
 
+uint64_t convertVectorToInt(const std::vector<bool>& v);
+
 uint64_t convertBytesVectorToInt(const std::vector<unsigned char>& bytes);
 
 void concatenateVectors(const std::vector<bool>& A, const std::vector<bool>& B, std::vector<bool>& result);

--- a/libzerocash/utils/util.h
+++ b/libzerocash/utils/util.h
@@ -2,6 +2,7 @@
 #define UTIL_H_
 
 #include <string>
+#include <stdexcept>
 #include <vector>
 #include <cstdint>
 

--- a/tests/utilTest.cpp
+++ b/tests/utilTest.cpp
@@ -40,6 +40,16 @@ BOOST_AUTO_TEST_CASE( testConvertVectorToInt ) {
     BOOST_CHECK(libzerocash::convertVectorToInt({1,1,0}) == 6);
 
     BOOST_CHECK_THROW(libzerocash::convertVectorToInt(std::vector<bool>(100)), std::length_error);
+
+    {
+        std::vector<bool> v(63, 1);
+        BOOST_CHECK(libzerocash::convertVectorToInt(v) == 0x7fffffffffffffff);
+    }
+
+    {
+        std::vector<bool> v(64, 1);
+        BOOST_CHECK(libzerocash::convertVectorToInt(v) == 0xffffffffffffffff);
+    }
 }
 
 BOOST_AUTO_TEST_CASE( testConvertBytesToVector ) {

--- a/tests/utilTest.cpp
+++ b/tests/utilTest.cpp
@@ -29,6 +29,19 @@ BOOST_AUTO_TEST_CASE( testGetRandBytes ) {
     BOOST_CHECK( memcmp(bytes1, bytes1+16, 16) != 0 );
 }
 
+BOOST_AUTO_TEST_CASE( testConvertVectorToInt ) {
+    BOOST_CHECK(libzerocash::convertVectorToInt({0}) == 0);
+    BOOST_CHECK(libzerocash::convertVectorToInt({1}) == 1);
+    BOOST_CHECK(libzerocash::convertVectorToInt({0,1}) == 1);
+    BOOST_CHECK(libzerocash::convertVectorToInt({1,0}) == 2);
+    BOOST_CHECK(libzerocash::convertVectorToInt({1,1}) == 3);
+    BOOST_CHECK(libzerocash::convertVectorToInt({1,0,0}) == 4);
+    BOOST_CHECK(libzerocash::convertVectorToInt({1,0,1}) == 5);
+    BOOST_CHECK(libzerocash::convertVectorToInt({1,1,0}) == 6);
+
+    BOOST_CHECK_THROW(libzerocash::convertVectorToInt(std::vector<bool>(100)), std::length_error);
+}
+
 BOOST_AUTO_TEST_CASE( testConvertBytesToVector ) {
     unsigned char bytes[5] = {0x00, 0x01, 0x03, 0x12, 0xFF};
     std::vector<bool> v1(5*8);

--- a/tests/zerocashTest.cpp
+++ b/tests/zerocashTest.cpp
@@ -299,15 +299,11 @@ bool test_pour(libzerocash::ZerocashParams& p,
         pour_outputs.push_back(libzerocash::PourOutput(*it));
     }
 
-    try {
-        libzerocash::PourTransaction pourtx(p, as, rt, pour_inputs, pour_outputs, vpub_in, vpub_out);
+    libzerocash::PourTransaction pourtx(p, as, rt, pour_inputs, pour_outputs, vpub_in, vpub_out);
 
-        assert(pourtx.verify(p, as, rt));
+    assert(pourtx.verify(p, as, rt));
 
-        return true;
-    } catch(...) {
-        return false;
-    }
+    return true;
 }
 
 BOOST_AUTO_TEST_CASE( PourVpubInTest ) {
@@ -329,17 +325,17 @@ BOOST_AUTO_TEST_CASE( PourVpubInTest ) {
     BOOST_CHECK(test_pour(p, 1, 0, {2, 2}, {2, 3}));
 
     // Things that should not work...
-    BOOST_CHECK(!test_pour(p, 0, 1, {1}, {1}));
-    BOOST_CHECK(!test_pour(p, 0, 1, {2}, {1, 1}));
-    BOOST_CHECK(!test_pour(p, 0, 1, {2, 2}, {3, 1}));
-    BOOST_CHECK(!test_pour(p, 0, 2, {1}, {}));
-    BOOST_CHECK(!test_pour(p, 0, 2, {2}, {1}));
-    BOOST_CHECK(!test_pour(p, 0, 2, {2, 2}, {2, 1}));
-    BOOST_CHECK(!test_pour(p, 1, 1, {}, {1}));
-    BOOST_CHECK(!test_pour(p, 1, 1, {1}, {1, 1}));
-    BOOST_CHECK(!test_pour(p, 1, 1, {2, 2}, {2, 3}));
+    BOOST_CHECK_THROW(test_pour(p, 0, 1, {1}, {1}), std::invalid_argument);
+    BOOST_CHECK_THROW(test_pour(p, 0, 1, {2}, {1, 1}), std::invalid_argument);
+    BOOST_CHECK_THROW(test_pour(p, 0, 1, {2, 2}, {3, 1}), std::invalid_argument);
+    BOOST_CHECK_THROW(test_pour(p, 0, 2, {1}, {}), std::invalid_argument);
+    BOOST_CHECK_THROW(test_pour(p, 0, 2, {2}, {1}), std::invalid_argument);
+    BOOST_CHECK_THROW(test_pour(p, 0, 2, {2, 2}, {2, 1}), std::invalid_argument);
+    BOOST_CHECK_THROW(test_pour(p, 1, 1, {}, {1}), std::invalid_argument);
+    BOOST_CHECK_THROW(test_pour(p, 1, 1, {1}, {1, 1}), std::invalid_argument);
+    BOOST_CHECK_THROW(test_pour(p, 1, 1, {2, 2}, {2, 3}), std::invalid_argument);
 
-    BOOST_CHECK(!test_pour(p, 0, 0, {2, 2}, {2, 3}));
+    BOOST_CHECK_THROW(test_pour(p, 0, 0, {2, 2}, {2, 3}), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE( CoinTest ) {

--- a/tests/zerocashTest.cpp
+++ b/tests/zerocashTest.cpp
@@ -25,6 +25,8 @@
 #include "libzerocash/IncrementalMerkleTree.h"
 #include "libzerocash/MintTransaction.h"
 #include "libzerocash/PourTransaction.h"
+#include "libzerocash/PourInput.h"
+#include "libzerocash/PourOutput.h"
 #include "libzerocash/utils/util.h"
 
 using namespace std;
@@ -218,6 +220,120 @@ BOOST_AUTO_TEST_CASE( SaveAndLoadKeysFromFiles ) {
     bool pourtx_res = pourtxNew.verify(p, pubkeyHash, rt);
 
     BOOST_CHECK(minttx_res && pourtx_res);
+}
+
+BOOST_AUTO_TEST_CASE( PourInputOutputTest ) {
+    // dummy input
+    {
+        libzerocash::PourInput input(TEST_TREE_DEPTH);
+
+        BOOST_CHECK(input.old_coin.getValue() == 0);
+        BOOST_CHECK(input.old_address.getPublicAddress() == input.old_coin.getPublicAddress());
+    }
+
+    // dummy output
+    {
+        libzerocash::PourOutput output;
+
+        BOOST_CHECK(output.new_coin.getValue() == 0);
+        BOOST_CHECK(output.to_address == output.new_coin.getPublicAddress());
+    }
+}
+
+// testing with general situational setup
+bool test_pour(libzerocash::ZerocashParams& p,
+          uint64_t vpub_in,
+          uint64_t vpub_out,
+          std::vector<uint64_t> inputs, // values of the inputs (max 2)
+          std::vector<uint64_t> outputs) // values of the outputs (max 2)
+{
+    using pour_input_state = std::tuple<libzerocash::Address, libzerocash::Coin, std::vector<bool>>;
+
+    // Construct incremental merkle tree
+    libzerocash::IncrementalMerkleTree merkleTree(TEST_TREE_DEPTH);
+
+    // Dummy sig_pk
+    vector<unsigned char> as(sig_pk_size, 'a');
+
+    vector<libzerocash::PourInput> pour_inputs;
+    vector<libzerocash::PourOutput> pour_outputs;
+
+    vector<pour_input_state> input_state;
+
+    for(std::vector<uint64_t>::iterator it = inputs.begin(); it != inputs.end(); ++it) {
+        libzerocash::Address addr;
+        libzerocash::Coin coin(addr.getPublicAddress(), *it);
+
+        // commitment from coin
+        std::vector<bool> commitment(cm_size * 8);
+        libzerocash::convertBytesVectorToVector(coin.getCoinCommitment().getCommitmentValue(), commitment);
+
+        // insert commitment into the merkle tree
+        std::vector<bool> index;
+        merkleTree.insertElement(commitment, index);
+
+        // store the state temporarily
+        input_state.push_back(std::make_tuple(addr, coin, index));
+    }
+
+    // compute the merkle root we will be working with
+    vector<unsigned char> rt(root_size);
+    {
+        vector<bool> root_bv(root_size * 8);
+        merkleTree.getRootValue(root_bv);
+        libzerocash::convertVectorToBytesVector(root_bv, rt);
+    }
+
+    // get witnesses for all the input coins and construct the pours
+    for(vector<pour_input_state>::iterator it = input_state.begin(); it != input_state.end(); ++it) {
+        merkle_authentication_path path(TEST_TREE_DEPTH);
+
+        auto index = std::get<2>(*it);
+        merkleTree.getWitness(index, path);
+
+        pour_inputs.push_back(libzerocash::PourInput(std::get<1>(*it), std::get<0>(*it), libzerocash::convertVectorToInt(index), path));
+    }
+
+    // construct dummy outputs with the given values
+    for(vector<uint64_t>::iterator it = outputs.begin(); it != outputs.end(); ++it) {
+        pour_outputs.push_back(libzerocash::PourOutput(*it));
+    }
+
+    libzerocash::PourTransaction pourtx(p, as, rt, pour_inputs, pour_outputs, vpub_in, vpub_out);
+
+    return pourtx.verify(p, as, rt);
+}
+
+BOOST_AUTO_TEST_CASE( PourVpubInTest ) {
+    auto keypair = libzerocash::ZerocashParams::GenerateNewKeyPair(TEST_TREE_DEPTH);
+    libzerocash::ZerocashParams p(
+        TEST_TREE_DEPTH,
+        &keypair
+    );
+
+    // Things that should work..
+    BOOST_CHECK(test_pour(p, 0, 0, {1}, {1}));
+    BOOST_CHECK(test_pour(p, 0, 0, {2}, {1, 1}));
+    BOOST_CHECK(test_pour(p, 0, 0, {2, 2}, {3, 1}));
+    BOOST_CHECK(test_pour(p, 0, 1, {1}, {}));
+    BOOST_CHECK(test_pour(p, 0, 1, {2}, {1}));
+    BOOST_CHECK(test_pour(p, 0, 1, {2, 2}, {2, 1}));
+    BOOST_CHECK(test_pour(p, 1, 0, {}, {1}));
+    BOOST_CHECK(test_pour(p, 1, 0, {1}, {1, 1}));
+    BOOST_CHECK(test_pour(p, 1, 0, {2, 2}, {2, 3}));
+
+    // Things that should not work...
+    BOOST_CHECK(!test_pour(p, 0, 1, {1}, {1}));
+    BOOST_CHECK(!test_pour(p, 0, 1, {2}, {1, 1}));
+    BOOST_CHECK(!test_pour(p, 0, 1, {2, 2}, {3, 1}));
+    BOOST_CHECK(!test_pour(p, 0, 2, {1}, {}));
+    BOOST_CHECK(!test_pour(p, 0, 2, {2}, {1}));
+    BOOST_CHECK(!test_pour(p, 0, 2, {2, 2}, {2, 1}));
+    BOOST_CHECK(!test_pour(p, 1, 1, {}, {1}));
+    BOOST_CHECK(!test_pour(p, 1, 1, {1}, {1, 1}));
+    BOOST_CHECK(!test_pour(p, 1, 1, {2, 2}, {2, 3}));
+
+    BOOST_CHECK(!test_pour(p, 0, 0, {2, 2}, {2, 3}));
 }
 
 BOOST_AUTO_TEST_CASE( CoinTest ) {

--- a/tests/zerocashTest.cpp
+++ b/tests/zerocashTest.cpp
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE( PourInputOutputTest ) {
 
     // dummy output
     {
-        libzerocash::PourOutput output;
+        libzerocash::PourOutput output(0);
 
         BOOST_CHECK(output.new_coin.getValue() == 0);
         BOOST_CHECK(output.to_address == output.new_coin.getPublicAddress());

--- a/tests/zerocashTest.cpp
+++ b/tests/zerocashTest.cpp
@@ -198,6 +198,7 @@ BOOST_AUTO_TEST_CASE( SaveAndLoadKeysFromFiles ) {
     		witness_1, witness_2,
     		pubAddress3, pubAddress4,
     		0,
+            0,
     		as,
     		c_1_new, c_2_new);
     cout << "Successfully created a pour transaction.\n" << endl;
@@ -390,7 +391,7 @@ BOOST_AUTO_TEST_CASE( PourTxTest ) {
     cout << "Creating a pour transaction...\n" << endl;
 
     libzerocash::timer_start("Pour Transaction");
-    libzerocash::PourTransaction pourtx(1, p, rt, coins.at(1), coins.at(3), addrs.at(1), addrs.at(3), 1, 3, witness_1, witness_2, pubAddress3, pubAddress4, 0, as, c_1_new, c_2_new);
+    libzerocash::PourTransaction pourtx(1, p, rt, coins.at(1), coins.at(3), addrs.at(1), addrs.at(3), 1, 3, witness_1, witness_2, pubAddress3, pubAddress4, 0, 0, as, c_1_new, c_2_new);
     libzerocash::timer_stop("Pour Transaction");
     print_mem("after pour transaction");
 
@@ -613,6 +614,7 @@ BOOST_AUTO_TEST_CASE( SimpleTxTest ) {
                 witness_1, witness_2,
     		pubAddress3, pubAddress4,
     		0,
+            0,
     		as,
     		c_1_new, c_2_new);
     cout << "Successfully created a pour transaction.\n" << endl;

--- a/tests/zerocashTest.cpp
+++ b/tests/zerocashTest.cpp
@@ -261,7 +261,7 @@ bool test_pour(libzerocash::ZerocashParams& p,
     vector<pour_input_state> input_state;
 
     for(std::vector<uint64_t>::iterator it = inputs.begin(); it != inputs.end(); ++it) {
-        libzerocash::Address addr;
+        libzerocash::Address addr = libzerocash::Address::CreateNewRandomAddress();
         libzerocash::Coin coin(addr.getPublicAddress(), *it);
 
         // commitment from coin

--- a/tests/zerocashTest.cpp
+++ b/tests/zerocashTest.cpp
@@ -299,9 +299,15 @@ bool test_pour(libzerocash::ZerocashParams& p,
         pour_outputs.push_back(libzerocash::PourOutput(*it));
     }
 
-    libzerocash::PourTransaction pourtx(p, as, rt, pour_inputs, pour_outputs, vpub_in, vpub_out);
+    try {
+        libzerocash::PourTransaction pourtx(p, as, rt, pour_inputs, pour_outputs, vpub_in, vpub_out);
 
-    return pourtx.verify(p, as, rt);
+        assert(pourtx.verify(p, as, rt));
+
+        return true;
+    } catch(...) {
+        return false;
+    }
 }
 
 BOOST_AUTO_TEST_CASE( PourVpubInTest ) {
@@ -626,7 +632,7 @@ BOOST_AUTO_TEST_CASE( MerkleTreeSimpleTest ) {
     libzerocash::hashVectors(inter_1, inter_2, wit3);
 
     BOOST_CHECK(witness.size() == 64);
-    for (size_t i = 0; i < 61 /* 61 */; i++) {
+    for (size_t i = 0; i < 61; i++) {
         BOOST_CHECK(witness.at(i) == zeros);
     }
     BOOST_CHECK(

--- a/tests/zerocashTest.cpp
+++ b/tests/zerocashTest.cpp
@@ -253,7 +253,7 @@ bool test_pour(libzerocash::ZerocashParams& p,
     libzerocash::IncrementalMerkleTree merkleTree(TEST_TREE_DEPTH);
 
     // Dummy sig_pk
-    vector<unsigned char> as(sig_pk_size, 'a');
+    vector<unsigned char> as(ZC_SIG_PK_SIZE, 'a');
 
     vector<libzerocash::PourInput> pour_inputs;
     vector<libzerocash::PourOutput> pour_outputs;
@@ -265,7 +265,7 @@ bool test_pour(libzerocash::ZerocashParams& p,
         libzerocash::Coin coin(addr.getPublicAddress(), *it);
 
         // commitment from coin
-        std::vector<bool> commitment(cm_size * 8);
+        std::vector<bool> commitment(ZC_CM_SIZE * 8);
         libzerocash::convertBytesVectorToVector(coin.getCoinCommitment().getCommitmentValue(), commitment);
 
         // insert commitment into the merkle tree
@@ -277,9 +277,9 @@ bool test_pour(libzerocash::ZerocashParams& p,
     }
 
     // compute the merkle root we will be working with
-    vector<unsigned char> rt(root_size);
+    vector<unsigned char> rt(ZC_ROOT_SIZE);
     {
-        vector<bool> root_bv(root_size * 8);
+        vector<bool> root_bv(ZC_ROOT_SIZE * 8);
         merkleTree.getRootValue(root_bv);
         libzerocash::convertVectorToBytesVector(root_bv, rt);
     }

--- a/zerocash_pour_ppzksnark/tests/test_zerocash_pour_ppzksnark.cpp
+++ b/zerocash_pour_ppzksnark/tests/test_zerocash_pour_ppzksnark.cpp
@@ -146,7 +146,8 @@ void test_zerocash_pour_ppzksnark(const size_t num_old_coins, const size_t num_n
     std::vector<bit_vector> new_coin_serial_number_nonces(num_new_coins); //
     std::vector<bit_vector> old_coin_serial_number_nonces(num_old_coins); //
     std::vector<bit_vector> new_coin_values(num_new_coins); //
-    bit_vector public_value; //
+    bit_vector public_in_value; //
+    bit_vector public_out_value; //
     std::vector<bit_vector> old_coin_values(num_old_coins); //
     bit_vector signature_public_key_hash; //
 
@@ -159,7 +160,8 @@ void test_zerocash_pour_ppzksnark(const size_t num_old_coins, const size_t num_n
     std::transform(old_coin_values_as_integers.begin(), old_coin_values_as_integers.end(),
                    old_coin_values.begin(),
                    [] (const size_t value) { return int_to_bit_vector(value, coin_value_length); });
-    public_value = int_to_bit_vector(all_new_values_as_integers[0], coin_value_length);
+    public_in_value = int_to_bit_vector(0, coin_value_length);
+    public_out_value = int_to_bit_vector(all_new_values_as_integers[0], coin_value_length);
     std::transform(all_new_values_as_integers.begin() + 1, all_new_values_as_integers.end(),
                    new_coin_values.begin(),
                    [] (const size_t value) { return int_to_bit_vector(value, coin_value_length); });
@@ -268,7 +270,8 @@ void test_zerocash_pour_ppzksnark(const size_t num_old_coins, const size_t num_n
                                new_coin_serial_number_nonces,
                                old_coin_serial_number_nonces,
                                new_coin_values,
-                               public_value,
+                               public_in_value,
+                               public_out_value,
                                old_coin_values,
                                signature_public_key_hash);
     assert(pb.is_satisfied());
@@ -291,7 +294,8 @@ void test_zerocash_pour_ppzksnark(const size_t num_old_coins, const size_t num_n
                                                                          new_coin_serial_number_nonces,
                                                                          old_coin_serial_number_nonces,
                                                                          new_coin_values,
-                                                                         public_value,
+                                                                         public_in_value,
+                                                                         public_out_value,
                                                                          old_coin_values,
                                                                          signature_public_key_hash);
     proof = reserialize<zerocash_pour_proof<ppT> >(proof);
@@ -300,7 +304,8 @@ void test_zerocash_pour_ppzksnark(const size_t num_old_coins, const size_t num_n
                                                                            merkle_tree_root,
                                                                            old_coin_serial_numbers,
                                                                            new_coin_commitments,
-                                                                           public_value,
+                                                                           public_in_value,
+                                                                           public_out_value,
                                                                            signature_public_key_hash,
                                                                            signature_public_key_hash_macs,
                                                                            proof);

--- a/zerocash_pour_ppzksnark/tests/test_zerocash_pour_ppzksnark.cpp
+++ b/zerocash_pour_ppzksnark/tests/test_zerocash_pour_ppzksnark.cpp
@@ -283,7 +283,7 @@ void test_zerocash_pour_ppzksnark(const size_t num_old_coins, const size_t num_n
     zerocash_pour_keypair<ppT> keypair = zerocash_pour_ppzksnark_generator<ppT>(num_old_coins, num_new_coins, tree_depth);
     keypair = reserialize<zerocash_pour_keypair<ppT> >(keypair);
 
-    zerocash_pour_proof<ppT> proof = zerocash_pour_ppzksnark_prover<ppT>(keypair.pk,
+    zerocash_pour_proof<ppT> proof = *zerocash_pour_ppzksnark_prover<ppT>(keypair.pk,
                                                                          old_coin_authentication_paths,
                                                                          old_coin_merkle_tree_positions,
                                                                          merkle_tree_root,

--- a/zerocash_pour_ppzksnark/tests/test_zerocash_pour_ppzksnark.cpp
+++ b/zerocash_pour_ppzksnark/tests/test_zerocash_pour_ppzksnark.cpp
@@ -256,28 +256,28 @@ void test_zerocash_pour_ppzksnark(const size_t num_old_coins, const size_t num_n
     }
 
     /* perform basic sanity checks */
-#ifdef DEBUG
-    protoboard<FieldT> pb;
-    zerocash_pour_gadget<FieldT> pour(pb, num_old_coins, num_new_coins, tree_depth, "pour");
-    pour.generate_r1cs_constraints();
-    pour.generate_r1cs_witness(old_coin_authentication_paths,
-                               old_coin_merkle_tree_positions,
-                               merkle_tree_root,
-                               new_address_public_keys,
-                               old_address_secret_keys,
-                               new_address_commitment_nonces,
-                               old_address_commitment_nonces,
-                               new_coin_serial_number_nonces,
-                               old_coin_serial_number_nonces,
-                               new_coin_values,
-                               public_in_value,
-                               public_out_value,
-                               old_coin_values,
-                               signature_public_key_hash);
-    assert(pb.is_satisfied());
-    printf("gadget test OK for num_old_coins = %zu, num_new_coins = %zu, tree_depth = %zu\n",
-           num_old_coins, num_new_coins, tree_depth);
-#endif
+    {
+        protoboard<FieldT> pb;
+        zerocash_pour_gadget<FieldT> pour(pb, num_old_coins, num_new_coins, tree_depth, "pour");
+        pour.generate_r1cs_constraints();
+        pour.generate_r1cs_witness(old_coin_authentication_paths,
+                                   old_coin_merkle_tree_positions,
+                                   merkle_tree_root,
+                                   new_address_public_keys,
+                                   old_address_secret_keys,
+                                   new_address_commitment_nonces,
+                                   old_address_commitment_nonces,
+                                   new_coin_serial_number_nonces,
+                                   old_coin_serial_number_nonces,
+                                   new_coin_values,
+                                   public_in_value,
+                                   public_out_value,
+                                   old_coin_values,
+                                   signature_public_key_hash);
+        assert(pb.is_satisfied());
+        printf("gadget test OK for num_old_coins = %zu, num_new_coins = %zu, tree_depth = %zu\n",
+               num_old_coins, num_new_coins, tree_depth);
+    }
 
     /* do the end-to-end test */
     zerocash_pour_keypair<ppT> keypair = zerocash_pour_ppzksnark_generator<ppT>(num_old_coins, num_new_coins, tree_depth);

--- a/zerocash_pour_ppzksnark/tests/test_zerocash_pour_ppzksnark.cpp
+++ b/zerocash_pour_ppzksnark/tests/test_zerocash_pour_ppzksnark.cpp
@@ -283,7 +283,7 @@ void test_zerocash_pour_ppzksnark(const size_t num_old_coins, const size_t num_n
     zerocash_pour_keypair<ppT> keypair = zerocash_pour_ppzksnark_generator<ppT>(num_old_coins, num_new_coins, tree_depth);
     keypair = reserialize<zerocash_pour_keypair<ppT> >(keypair);
 
-    zerocash_pour_proof<ppT> proof = *zerocash_pour_ppzksnark_prover<ppT>(keypair.pk,
+    zerocash_pour_proof<ppT> proof = zerocash_pour_ppzksnark_prover<ppT>(keypair.pk,
                                                                          old_coin_authentication_paths,
                                                                          old_coin_merkle_tree_positions,
                                                                          merkle_tree_root,

--- a/zerocash_pour_ppzksnark/zerocash_pour_gadget.hpp
+++ b/zerocash_pour_ppzksnark/zerocash_pour_gadget.hpp
@@ -94,7 +94,8 @@ public:
     std::shared_ptr<digest_variable<FieldT> > merkle_tree_root_variable;
     std::vector<std::shared_ptr<digest_variable<FieldT> > > old_coin_serial_number_variables;
     std::vector<std::shared_ptr<digest_variable<FieldT> > > new_coin_commitment_variables;
-    pb_variable_array<FieldT> public_value_variable;
+    pb_variable_array<FieldT> public_in_value_variable;
+    pb_variable_array<FieldT> public_out_value_variable;
     std::shared_ptr<digest_variable<FieldT> > signature_public_key_hash_variable;
     std::vector<std::shared_ptr<digest_variable<FieldT> > > mac_of_signature_public_key_hash_variables;
 
@@ -162,7 +163,8 @@ public:
                                const std::vector<bit_vector> &new_coin_serial_number_nonces,
                                const std::vector<bit_vector> &old_coin_serial_number_nonces,
                                const std::vector<bit_vector> &new_coin_values,
-                               const bit_vector &public_value,
+                               const bit_vector &public_in_value,
+                               const bit_vector &public_out_value,
                                const std::vector<bit_vector> &old_coin_values,
                                const bit_vector &signature_public_key_hash);
 };
@@ -173,7 +175,8 @@ r1cs_primary_input<FieldT> zerocash_pour_input_map(const size_t num_old_coins,
                                                    const bit_vector &merkle_tree_root,
                                                    const std::vector<bit_vector> &old_coin_serial_numbers,
                                                    const std::vector<bit_vector> &new_coin_commitments,
-                                                   const bit_vector &public_value,
+                                                   const bit_vector &public_in_value,
+                                                   const bit_vector &public_out_value,
                                                    const bit_vector &signature_public_key_hash,
                                                    const std::vector<bit_vector> &signature_public_key_hash_macs);
 

--- a/zerocash_pour_ppzksnark/zerocash_pour_gadget.hpp
+++ b/zerocash_pour_ppzksnark/zerocash_pour_gadget.hpp
@@ -95,8 +95,8 @@ public:
     std::vector<std::shared_ptr<digest_variable<FieldT> > > old_coin_serial_number_variables;
     pb_variable_array<FieldT> old_coin_enforce_commitment;
     std::vector<std::shared_ptr<digest_variable<FieldT> > > new_coin_commitment_variables;
-    pb_variable_array<FieldT> public_in_value_variable;
-    pb_variable_array<FieldT> public_out_value_variable;
+    pb_variable_array<FieldT> public_old_value_variable;
+    pb_variable_array<FieldT> public_new_value_variable;
     std::shared_ptr<digest_variable<FieldT> > signature_public_key_hash_variable;
     std::vector<std::shared_ptr<digest_variable<FieldT> > > mac_of_signature_public_key_hash_variables;
 
@@ -164,8 +164,8 @@ public:
                                const std::vector<bit_vector> &new_coin_serial_number_nonces,
                                const std::vector<bit_vector> &old_coin_serial_number_nonces,
                                const std::vector<bit_vector> &new_coin_values,
-                               const bit_vector &public_in_value,
-                               const bit_vector &public_out_value,
+                               const bit_vector &public_old_value,
+                               const bit_vector &public_new_value,
                                const std::vector<bit_vector> &old_coin_values,
                                const bit_vector &signature_public_key_hash);
 };
@@ -176,8 +176,8 @@ r1cs_primary_input<FieldT> zerocash_pour_input_map(const size_t num_old_coins,
                                                    const bit_vector &merkle_tree_root,
                                                    const std::vector<bit_vector> &old_coin_serial_numbers,
                                                    const std::vector<bit_vector> &new_coin_commitments,
-                                                   const bit_vector &public_in_value,
-                                                   const bit_vector &public_out_value,
+                                                   const bit_vector &public_old_value,
+                                                   const bit_vector &public_new_value,
                                                    const bit_vector &signature_public_key_hash,
                                                    const std::vector<bit_vector> &signature_public_key_hash_macs);
 

--- a/zerocash_pour_ppzksnark/zerocash_pour_gadget.hpp
+++ b/zerocash_pour_ppzksnark/zerocash_pour_gadget.hpp
@@ -93,6 +93,7 @@ public:
     /* individual components of the unpacked R1CS input */
     std::shared_ptr<digest_variable<FieldT> > merkle_tree_root_variable;
     std::vector<std::shared_ptr<digest_variable<FieldT> > > old_coin_serial_number_variables;
+    pb_variable_array<FieldT> old_coin_enforce_commitment;
     std::vector<std::shared_ptr<digest_variable<FieldT> > > new_coin_commitment_variables;
     pb_variable_array<FieldT> public_in_value_variable;
     pb_variable_array<FieldT> public_out_value_variable;

--- a/zerocash_pour_ppzksnark/zerocash_pour_gadget.tcc
+++ b/zerocash_pour_ppzksnark/zerocash_pour_gadget.tcc
@@ -48,8 +48,8 @@ zerocash_pour_gadget<FieldT>::zerocash_pour_gadget(protoboard<FieldT> &pb,
         new_coin_commitment_variables[i].reset(new digest_variable<FieldT>(pb, sha256_digest_len, FMT(annotation_prefix, " new_coin_commitment_variables_%zu", i)));
     }
 
-    public_in_value_variable.allocate(pb, coin_value_length, FMT(annotation_prefix, " public_in_value_variable"));
-    public_out_value_variable.allocate(pb, coin_value_length, FMT(annotation_prefix, " public_out_value_variable"));
+    public_old_value_variable.allocate(pb, coin_value_length, FMT(annotation_prefix, " public_old_value_variable"));
+    public_new_value_variable.allocate(pb, coin_value_length, FMT(annotation_prefix, " public_new_value_variable"));
     signature_public_key_hash_variable.reset(new digest_variable<FieldT>(pb, sha256_digest_len, FMT(annotation_prefix, " signature_public_key_hash")));
 
     mac_of_signature_public_key_hash_variables.resize(num_old_coins);
@@ -68,8 +68,8 @@ zerocash_pour_gadget<FieldT>::zerocash_pour_gadget(protoboard<FieldT> &pb,
     {
         input_as_bits.insert(input_as_bits.end(), new_coin_commitment_variables[i]->bits.begin(), new_coin_commitment_variables[i]->bits.end());
     }
-    input_as_bits.insert(input_as_bits.end(), public_in_value_variable.begin(), public_in_value_variable.end());
-    input_as_bits.insert(input_as_bits.end(), public_out_value_variable.begin(), public_out_value_variable.end());
+    input_as_bits.insert(input_as_bits.end(), public_old_value_variable.begin(), public_old_value_variable.end());
+    input_as_bits.insert(input_as_bits.end(), public_new_value_variable.begin(), public_new_value_variable.end());
     input_as_bits.insert(input_as_bits.end(), signature_public_key_hash_variable->bits.begin(), signature_public_key_hash_variable->bits.end());
     for (size_t i = 0; i < num_old_coins; ++i)
     {
@@ -325,14 +325,14 @@ void zerocash_pour_gadget<FieldT>::generate_r1cs_constraints()
     {
         old_packed_value = old_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(old_coin_value_variables[i].rbegin(), old_coin_value_variables[i].rend()));
     }
-    old_packed_value = old_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(public_in_value_variable.rbegin(), public_in_value_variable.rend()));
+    old_packed_value = old_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(public_old_value_variable.rbegin(), public_old_value_variable.rend()));
 
     linear_combination<FieldT> new_packed_value;
     for (size_t i = 0; i < num_new_coins; ++i)
     {
         new_packed_value = new_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(new_coin_value_variables[i].rbegin(), new_coin_value_variables[i].rend()));
     }
-    new_packed_value = new_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(public_out_value_variable.rbegin(), public_out_value_variable.rend()));
+    new_packed_value = new_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(public_new_value_variable.rbegin(), public_new_value_variable.rend()));
 
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, old_packed_value, new_packed_value), FMT(this->annotation_prefix, " balance"));
 }
@@ -348,8 +348,8 @@ void zerocash_pour_gadget<FieldT>::generate_r1cs_witness(const std::vector<merkl
                                                          const std::vector<bit_vector> &new_coin_serial_number_nonces,
                                                          const std::vector<bit_vector> &old_coin_serial_number_nonces,
                                                          const std::vector<bit_vector> &new_coin_values,
-                                                         const bit_vector &public_in_value,
-                                                         const bit_vector &public_out_value,
+                                                         const bit_vector &public_old_value,
+                                                         const bit_vector &public_new_value,
                                                          const std::vector<bit_vector> &old_coin_values,
                                                          const bit_vector &signature_public_key_hash)
 {
@@ -392,8 +392,8 @@ void zerocash_pour_gadget<FieldT>::generate_r1cs_witness(const std::vector<merkl
         }
     }
 
-    public_in_value_variable.fill_with_bits(this->pb, public_in_value);
-    public_out_value_variable.fill_with_bits(this->pb, public_out_value);
+    public_old_value_variable.fill_with_bits(this->pb, public_old_value);
+    public_new_value_variable.fill_with_bits(this->pb, public_new_value);
     signature_public_key_hash_variable->generate_r1cs_witness(signature_public_key_hash);
 
     /* do the hashing */
@@ -442,8 +442,8 @@ r1cs_primary_input<FieldT> zerocash_pour_input_map(const size_t num_old_coins,
                                                    const bit_vector &merkle_tree_root,
                                                    const std::vector<bit_vector> &old_coin_serial_numbers,
                                                    const std::vector<bit_vector> &new_coin_commitments,
-                                                   const bit_vector &public_in_value,
-                                                   const bit_vector &public_out_value,
+                                                   const bit_vector &public_old_value,
+                                                   const bit_vector &public_new_value,
                                                    const bit_vector &signature_public_key_hash,
                                                    const std::vector<bit_vector> &signature_public_key_hash_macs)
 {
@@ -459,8 +459,8 @@ r1cs_primary_input<FieldT> zerocash_pour_input_map(const size_t num_old_coins,
     {
         assert(new_coin_commitment.size() == coin_commitment_length);
     }
-    assert(public_in_value.size() == coin_value_length);
-    assert(public_out_value.size() == coin_value_length);
+    assert(public_old_value.size() == coin_value_length);
+    assert(public_new_value.size() == coin_value_length);
     assert(signature_public_key_hash.size() == sha256_digest_len);
     assert(signature_public_key_hash_macs.size() == num_old_coins);
     for (auto &signature_public_key_hash_mac : signature_public_key_hash_macs)
@@ -479,8 +479,8 @@ r1cs_primary_input<FieldT> zerocash_pour_input_map(const size_t num_old_coins,
     {
         input_as_bits.insert(input_as_bits.end(), new_coin_commitment.begin(), new_coin_commitment.end());
     }
-    input_as_bits.insert(input_as_bits.end(), public_in_value.begin(), public_in_value.end());
-    input_as_bits.insert(input_as_bits.end(), public_out_value.begin(), public_out_value.end());
+    input_as_bits.insert(input_as_bits.end(), public_old_value.begin(), public_old_value.end());
+    input_as_bits.insert(input_as_bits.end(), public_new_value.begin(), public_new_value.end());
     input_as_bits.insert(input_as_bits.end(), signature_public_key_hash.begin(), signature_public_key_hash.end());
     for (auto &signature_public_key_hash_mac : signature_public_key_hash_macs)
     {

--- a/zerocash_pour_ppzksnark/zerocash_pour_gadget.tcc
+++ b/zerocash_pour_ppzksnark/zerocash_pour_gadget.tcc
@@ -380,12 +380,18 @@ void zerocash_pour_gadget<FieldT>::generate_r1cs_witness(const std::vector<merkl
 
     for (size_t i = 0; i < num_old_coins; ++i)
     {
+        this->pb.val(old_coin_enforce_commitment[i]) = FieldT::zero();
         old_coin_serial_number_nonce_variables[i].fill_with_bits(this->pb, old_coin_serial_number_nonces[i]);
         old_coin_value_variables[i].fill_with_bits(this->pb, old_coin_values[i]);
 
         for (size_t j = 0; j < coin_value_length; ++j)
         {
-            this->pb.val(old_coin_enforce_commitment[i]) = (old_coin_values[i][j] ? FieldT::one() : FieldT::zero());
+            if (old_coin_values[i][j]) {
+                // If any bit in the value is nonzero, the value is nonzero.
+                // Thus, the old coin must be committed in the tree.
+                this->pb.val(old_coin_enforce_commitment[i]) = FieldT::one();
+                break;
+            }
         }
     }
 

--- a/zerocash_pour_ppzksnark/zerocash_pour_gadget.tcc
+++ b/zerocash_pour_ppzksnark/zerocash_pour_gadget.tcc
@@ -308,9 +308,6 @@ void zerocash_pour_gadget<FieldT>::generate_r1cs_constraints()
         {
             generate_boolean_r1cs_constraint<FieldT>(this->pb, new_coin_value_variables[i][j], FMT(this->annotation_prefix, " new_coin_value_variables_%zu_%zu", i, j));
         }
-
-        generate_boolean_r1cs_constraint<FieldT>(this->pb, public_in_value_variable[j], FMT(this->annotation_prefix, " public_in_value_variable_%zu", j));
-        generate_boolean_r1cs_constraint<FieldT>(this->pb, public_out_value_variable[j], FMT(this->annotation_prefix, " public_out_value_variable_%zu", j));
     }
 
     for (size_t i = 0; i < num_old_coins; ++i)

--- a/zerocash_pour_ppzksnark/zerocash_pour_gadget.tcc
+++ b/zerocash_pour_ppzksnark/zerocash_pour_gadget.tcc
@@ -27,7 +27,7 @@ zerocash_pour_gadget<FieldT>::zerocash_pour_gadget(protoboard<FieldT> &pb,
     num_new_coins(num_new_coins)
 {
     /* allocate packed inputs */
-    const size_t input_size_in_bits = sha256_digest_len + num_old_coins*sha256_digest_len + num_new_coins*sha256_digest_len + coin_value_length + (num_old_coins + 1) * sha256_digest_len;
+    const size_t input_size_in_bits = sha256_digest_len + num_old_coins*sha256_digest_len + num_new_coins*sha256_digest_len + (coin_value_length * 2) + (num_old_coins + 1) * sha256_digest_len;
     const size_t input_size_in_field_elements = div_ceil(input_size_in_bits, FieldT::capacity());
     input_as_field_elements.allocate(pb, input_size_in_field_elements, FMT(annotation_prefix, " input_as_field_elements"));
     this->pb.set_input_sizes(input_size_in_field_elements);
@@ -47,7 +47,8 @@ zerocash_pour_gadget<FieldT>::zerocash_pour_gadget(protoboard<FieldT> &pb,
         new_coin_commitment_variables[i].reset(new digest_variable<FieldT>(pb, sha256_digest_len, FMT(annotation_prefix, " new_coin_commitment_variables_%zu", i)));
     }
 
-    public_value_variable.allocate(pb, coin_value_length, FMT(annotation_prefix, " public_value_variable"));
+    public_in_value_variable.allocate(pb, coin_value_length, FMT(annotation_prefix, " public_in_value_variable"));
+    public_out_value_variable.allocate(pb, coin_value_length, FMT(annotation_prefix, " public_out_value_variable"));
     signature_public_key_hash_variable.reset(new digest_variable<FieldT>(pb, sha256_digest_len, FMT(annotation_prefix, " signature_public_key_hash")));
 
     mac_of_signature_public_key_hash_variables.resize(num_old_coins);
@@ -66,7 +67,8 @@ zerocash_pour_gadget<FieldT>::zerocash_pour_gadget(protoboard<FieldT> &pb,
     {
         input_as_bits.insert(input_as_bits.end(), new_coin_commitment_variables[i]->bits.begin(), new_coin_commitment_variables[i]->bits.end());
     }
-    input_as_bits.insert(input_as_bits.end(), public_value_variable.begin(), public_value_variable.end());
+    input_as_bits.insert(input_as_bits.end(), public_in_value_variable.begin(), public_in_value_variable.end());
+    input_as_bits.insert(input_as_bits.end(), public_out_value_variable.begin(), public_out_value_variable.end());
     input_as_bits.insert(input_as_bits.end(), signature_public_key_hash_variable->bits.begin(), signature_public_key_hash_variable->bits.end());
     for (size_t i = 0; i < num_old_coins; ++i)
     {
@@ -306,7 +308,8 @@ void zerocash_pour_gadget<FieldT>::generate_r1cs_constraints()
             generate_boolean_r1cs_constraint<FieldT>(this->pb, new_coin_value_variables[i][j], FMT(this->annotation_prefix, " new_coin_value_variables_%zu_%zu", i, j));
         }
 
-        generate_boolean_r1cs_constraint<FieldT>(this->pb, public_value_variable[j], FMT(this->annotation_prefix, " public_value_variable_%zu", j));
+        generate_boolean_r1cs_constraint<FieldT>(this->pb, public_in_value_variable[j], FMT(this->annotation_prefix, " public_in_value_variable_%zu", j));
+        generate_boolean_r1cs_constraint<FieldT>(this->pb, public_out_value_variable[j], FMT(this->annotation_prefix, " public_out_value_variable_%zu", j));
     }
 
     /* check the balance equation */
@@ -315,13 +318,14 @@ void zerocash_pour_gadget<FieldT>::generate_r1cs_constraints()
     {
         old_packed_value = old_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(old_coin_value_variables[i].rbegin(), old_coin_value_variables[i].rend()));
     }
+    old_packed_value = old_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(public_in_value_variable.rbegin(), public_in_value_variable.rend()));
 
     linear_combination<FieldT> new_packed_value;
     for (size_t i = 0; i < num_new_coins; ++i)
     {
         new_packed_value = new_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(new_coin_value_variables[i].rbegin(), new_coin_value_variables[i].rend()));
     }
-    new_packed_value = new_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(public_value_variable.rbegin(), public_value_variable.rend()));
+    new_packed_value = new_packed_value + pb_packing_sum<FieldT>(pb_variable_array<FieldT>(public_out_value_variable.rbegin(), public_out_value_variable.rend()));
 
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, old_packed_value, new_packed_value), FMT(this->annotation_prefix, " balance"));
 }
@@ -337,7 +341,8 @@ void zerocash_pour_gadget<FieldT>::generate_r1cs_witness(const std::vector<merkl
                                                          const std::vector<bit_vector> &new_coin_serial_number_nonces,
                                                          const std::vector<bit_vector> &old_coin_serial_number_nonces,
                                                          const std::vector<bit_vector> &new_coin_values,
-                                                         const bit_vector &public_value,
+                                                         const bit_vector &public_in_value,
+                                                         const bit_vector &public_out_value,
                                                          const std::vector<bit_vector> &old_coin_values,
                                                          const bit_vector &signature_public_key_hash)
 {
@@ -369,7 +374,8 @@ void zerocash_pour_gadget<FieldT>::generate_r1cs_witness(const std::vector<merkl
         old_coin_value_variables[i].fill_with_bits(this->pb, old_coin_values[i]);
     }
 
-    public_value_variable.fill_with_bits(this->pb, public_value);
+    public_in_value_variable.fill_with_bits(this->pb, public_in_value);
+    public_out_value_variable.fill_with_bits(this->pb, public_out_value);
     signature_public_key_hash_variable->generate_r1cs_witness(signature_public_key_hash);
 
     /* do the hashing */
@@ -418,7 +424,8 @@ r1cs_primary_input<FieldT> zerocash_pour_input_map(const size_t num_old_coins,
                                                    const bit_vector &merkle_tree_root,
                                                    const std::vector<bit_vector> &old_coin_serial_numbers,
                                                    const std::vector<bit_vector> &new_coin_commitments,
-                                                   const bit_vector &public_value,
+                                                   const bit_vector &public_in_value,
+                                                   const bit_vector &public_out_value,
                                                    const bit_vector &signature_public_key_hash,
                                                    const std::vector<bit_vector> &signature_public_key_hash_macs)
 {
@@ -434,7 +441,8 @@ r1cs_primary_input<FieldT> zerocash_pour_input_map(const size_t num_old_coins,
     {
         assert(new_coin_commitment.size() == coin_commitment_length);
     }
-    assert(public_value.size() == coin_value_length);
+    assert(public_in_value.size() == coin_value_length);
+    assert(public_out_value.size() == coin_value_length);
     assert(signature_public_key_hash.size() == sha256_digest_len);
     assert(signature_public_key_hash_macs.size() == num_old_coins);
     for (auto &signature_public_key_hash_mac : signature_public_key_hash_macs)
@@ -453,7 +461,8 @@ r1cs_primary_input<FieldT> zerocash_pour_input_map(const size_t num_old_coins,
     {
         input_as_bits.insert(input_as_bits.end(), new_coin_commitment.begin(), new_coin_commitment.end());
     }
-    input_as_bits.insert(input_as_bits.end(), public_value.begin(), public_value.end());
+    input_as_bits.insert(input_as_bits.end(), public_in_value.begin(), public_in_value.end());
+    input_as_bits.insert(input_as_bits.end(), public_out_value.begin(), public_out_value.end());
     input_as_bits.insert(input_as_bits.end(), signature_public_key_hash.begin(), signature_public_key_hash.end());
     for (auto &signature_public_key_hash_mac : signature_public_key_hash_macs)
     {

--- a/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.hpp
+++ b/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.hpp
@@ -206,8 +206,8 @@ zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash
                                                                   const std::vector<bit_vector> &new_coin_serial_number_nonces,
                                                                   const std::vector<bit_vector> &old_coin_serial_number_nonces,
                                                                   const std::vector<bit_vector> &new_coin_values,
-                                                                  const bit_vector &public_in_value,
-                                                                  const bit_vector &public_out_value,
+                                                                  const bit_vector &public_old_value,
+                                                                  const bit_vector &public_new_value,
                                                                   const std::vector<bit_vector> &old_coin_values,
                                                                   const bit_vector &signature_public_key_hash);
 
@@ -219,8 +219,8 @@ bool zerocash_pour_ppzksnark_verifier(const zerocash_pour_verification_key<ppzks
                                       const bit_vector &merkle_tree_root,
                                       const std::vector<bit_vector> &old_coin_serial_numbers,
                                       const std::vector<bit_vector> &new_coin_commitments,
-                                      const bit_vector &public_in_value,
-                                      const bit_vector &public_out_value,
+                                      const bit_vector &public_old_value,
+                                      const bit_vector &public_new_value,
                                       const bit_vector &signature_public_key_hash,
                                       const std::vector<bit_vector> &signature_public_key_hash_macs,
                                       const zerocash_pour_proof<ppzksnark_ppT> &proof);

--- a/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.hpp
+++ b/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.hpp
@@ -205,7 +205,8 @@ zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash
                                                                   const std::vector<bit_vector> &new_coin_serial_number_nonces,
                                                                   const std::vector<bit_vector> &old_coin_serial_number_nonces,
                                                                   const std::vector<bit_vector> &new_coin_values,
-                                                                  const bit_vector &public_value,
+                                                                  const bit_vector &public_in_value,
+                                                                  const bit_vector &public_out_value,
                                                                   const std::vector<bit_vector> &old_coin_values,
                                                                   const bit_vector &signature_public_key_hash);
 
@@ -217,7 +218,8 @@ bool zerocash_pour_ppzksnark_verifier(const zerocash_pour_verification_key<ppzks
                                       const bit_vector &merkle_tree_root,
                                       const std::vector<bit_vector> &old_coin_serial_numbers,
                                       const std::vector<bit_vector> &new_coin_commitments,
-                                      const bit_vector &public_value,
+                                      const bit_vector &public_in_value,
+                                      const bit_vector &public_out_value,
                                       const bit_vector &signature_public_key_hash,
                                       const std::vector<bit_vector> &signature_public_key_hash_macs,
                                       const zerocash_pour_proof<ppzksnark_ppT> &proof);

--- a/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.hpp
+++ b/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.hpp
@@ -41,7 +41,6 @@
 
 #include "libsnark/common/data_structures/merkle_tree.hpp"
 #include "libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp"
-#include <boost/optional.hpp>
 
 namespace libzerocash {
 
@@ -195,21 +194,21 @@ zerocash_pour_keypair<ppzksnark_ppT> zerocash_pour_ppzksnark_generator(const siz
  * TODO: add description
  */
 template<typename ppzksnark_ppT>
-boost::optional<zerocash_pour_proof<ppzksnark_ppT>> zerocash_pour_ppzksnark_prover(const zerocash_pour_proving_key<ppzksnark_ppT> &pk,
-                                                                                    const std::vector<merkle_authentication_path> &old_coin_authentication_paths,
-                                                                                    const std::vector<size_t> &old_coin_merkle_tree_positions,
-                                                                                    const bit_vector &merkle_tree_root,
-                                                                                    const std::vector<bit_vector> &new_address_public_keys,
-                                                                                    const std::vector<bit_vector> &old_address_secret_keys,
-                                                                                    const std::vector<bit_vector> &new_address_commitment_nonces,
-                                                                                    const std::vector<bit_vector> &old_address_commitment_nonces,
-                                                                                    const std::vector<bit_vector> &new_coin_serial_number_nonces,
-                                                                                    const std::vector<bit_vector> &old_coin_serial_number_nonces,
-                                                                                    const std::vector<bit_vector> &new_coin_values,
-                                                                                    const bit_vector &public_in_value,
-                                                                                    const bit_vector &public_out_value,
-                                                                                    const std::vector<bit_vector> &old_coin_values,
-                                                                                    const bit_vector &signature_public_key_hash);
+zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash_pour_proving_key<ppzksnark_ppT> &pk,
+                                                                  const std::vector<merkle_authentication_path> &old_coin_authentication_paths,
+                                                                  const std::vector<size_t> &old_coin_merkle_tree_positions,
+                                                                  const bit_vector &merkle_tree_root,
+                                                                  const std::vector<bit_vector> &new_address_public_keys,
+                                                                  const std::vector<bit_vector> &old_address_secret_keys,
+                                                                  const std::vector<bit_vector> &new_address_commitment_nonces,
+                                                                  const std::vector<bit_vector> &old_address_commitment_nonces,
+                                                                  const std::vector<bit_vector> &new_coin_serial_number_nonces,
+                                                                  const std::vector<bit_vector> &old_coin_serial_number_nonces,
+                                                                  const std::vector<bit_vector> &new_coin_values,
+                                                                  const bit_vector &public_in_value,
+                                                                  const bit_vector &public_out_value,
+                                                                  const std::vector<bit_vector> &old_coin_values,
+                                                                  const bit_vector &signature_public_key_hash);
 
 /**
  * A verifier algorithm for the Pour ppzkSNARK.

--- a/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.hpp
+++ b/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.hpp
@@ -41,6 +41,7 @@
 
 #include "libsnark/common/data_structures/merkle_tree.hpp"
 #include "libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp"
+#include <stdexcept>
 
 namespace libzerocash {
 

--- a/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.hpp
+++ b/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.hpp
@@ -41,6 +41,7 @@
 
 #include "libsnark/common/data_structures/merkle_tree.hpp"
 #include "libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp"
+#include <boost/optional.hpp>
 
 namespace libzerocash {
 
@@ -194,21 +195,21 @@ zerocash_pour_keypair<ppzksnark_ppT> zerocash_pour_ppzksnark_generator(const siz
  * TODO: add description
  */
 template<typename ppzksnark_ppT>
-zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash_pour_proving_key<ppzksnark_ppT> &pk,
-                                                                  const std::vector<merkle_authentication_path> &old_coin_authentication_paths,
-                                                                  const std::vector<size_t> &old_coin_merkle_tree_positions,
-                                                                  const bit_vector &merkle_tree_root,
-                                                                  const std::vector<bit_vector> &new_address_public_keys,
-                                                                  const std::vector<bit_vector> &old_address_secret_keys,
-                                                                  const std::vector<bit_vector> &new_address_commitment_nonces,
-                                                                  const std::vector<bit_vector> &old_address_commitment_nonces,
-                                                                  const std::vector<bit_vector> &new_coin_serial_number_nonces,
-                                                                  const std::vector<bit_vector> &old_coin_serial_number_nonces,
-                                                                  const std::vector<bit_vector> &new_coin_values,
-                                                                  const bit_vector &public_in_value,
-                                                                  const bit_vector &public_out_value,
-                                                                  const std::vector<bit_vector> &old_coin_values,
-                                                                  const bit_vector &signature_public_key_hash);
+boost::optional<zerocash_pour_proof<ppzksnark_ppT>> zerocash_pour_ppzksnark_prover(const zerocash_pour_proving_key<ppzksnark_ppT> &pk,
+                                                                                    const std::vector<merkle_authentication_path> &old_coin_authentication_paths,
+                                                                                    const std::vector<size_t> &old_coin_merkle_tree_positions,
+                                                                                    const bit_vector &merkle_tree_root,
+                                                                                    const std::vector<bit_vector> &new_address_public_keys,
+                                                                                    const std::vector<bit_vector> &old_address_secret_keys,
+                                                                                    const std::vector<bit_vector> &new_address_commitment_nonces,
+                                                                                    const std::vector<bit_vector> &old_address_commitment_nonces,
+                                                                                    const std::vector<bit_vector> &new_coin_serial_number_nonces,
+                                                                                    const std::vector<bit_vector> &old_coin_serial_number_nonces,
+                                                                                    const std::vector<bit_vector> &new_coin_values,
+                                                                                    const bit_vector &public_in_value,
+                                                                                    const bit_vector &public_out_value,
+                                                                                    const std::vector<bit_vector> &old_coin_values,
+                                                                                    const bit_vector &signature_public_key_hash);
 
 /**
  * A verifier algorithm for the Pour ppzkSNARK.

--- a/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.tcc
+++ b/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.tcc
@@ -140,8 +140,8 @@ zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash
                                                                   const std::vector<bit_vector> &new_coin_serial_number_nonces,
                                                                   const std::vector<bit_vector> &old_coin_serial_number_nonces,
                                                                   const std::vector<bit_vector> &new_coin_values,
-                                                                  const bit_vector &public_in_value,
-                                                                  const bit_vector &public_out_value,
+                                                                  const bit_vector &public_old_value,
+                                                                  const bit_vector &public_new_value,
                                                                   const std::vector<bit_vector> &old_coin_values,
                                                                   const bit_vector &signature_public_key_hash)
 {
@@ -162,8 +162,8 @@ zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash
                             new_coin_serial_number_nonces,
                             old_coin_serial_number_nonces,
                             new_coin_values,
-                            public_in_value,
-                            public_out_value,
+                            public_old_value,
+                            public_new_value,
                             old_coin_values,
                             signature_public_key_hash);
     if (!pb.is_satisfied()) {
@@ -183,8 +183,8 @@ bool zerocash_pour_ppzksnark_verifier(const zerocash_pour_verification_key<ppzks
                                       const bit_vector &merkle_tree_root,
                                       const std::vector<bit_vector> &old_coin_serial_numbers,
                                       const std::vector<bit_vector> &new_coin_commitments,
-                                      const bit_vector &public_in_value,
-                                      const bit_vector &public_out_value,
+                                      const bit_vector &public_old_value,
+                                      const bit_vector &public_new_value,
                                       const bit_vector &signature_public_key_hash,
                                       const std::vector<bit_vector> &signature_public_key_hash_macs,
                                       const zerocash_pour_proof<ppzksnark_ppT> &proof)
@@ -197,8 +197,8 @@ bool zerocash_pour_ppzksnark_verifier(const zerocash_pour_verification_key<ppzks
                                                                              merkle_tree_root,
                                                                              old_coin_serial_numbers,
                                                                              new_coin_commitments,
-                                                                             public_in_value,
-                                                                             public_out_value,
+                                                                             public_old_value,
+                                                                             public_new_value,
                                                                              signature_public_key_hash,
                                                                              signature_public_key_hash_macs);
     const bool ans = r1cs_ppzksnark_verifier_strong_IC<ppzksnark_ppT>(vk.r1cs_vk, input, proof);

--- a/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.tcc
+++ b/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.tcc
@@ -140,7 +140,8 @@ zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash
                                                                   const std::vector<bit_vector> &new_coin_serial_number_nonces,
                                                                   const std::vector<bit_vector> &old_coin_serial_number_nonces,
                                                                   const std::vector<bit_vector> &new_coin_values,
-                                                                  const bit_vector &public_value,
+                                                                  const bit_vector &public_in_value,
+                                                                  const bit_vector &public_out_value,
                                                                   const std::vector<bit_vector> &old_coin_values,
                                                                   const bit_vector &signature_public_key_hash)
 {
@@ -161,7 +162,8 @@ zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash
                             new_coin_serial_number_nonces,
                             old_coin_serial_number_nonces,
                             new_coin_values,
-                            public_value,
+                            public_in_value,
+                            public_out_value,
                             old_coin_values,
                             signature_public_key_hash);
     assert(pb.is_satisfied());
@@ -177,7 +179,8 @@ bool zerocash_pour_ppzksnark_verifier(const zerocash_pour_verification_key<ppzks
                                       const bit_vector &merkle_tree_root,
                                       const std::vector<bit_vector> &old_coin_serial_numbers,
                                       const std::vector<bit_vector> &new_coin_commitments,
-                                      const bit_vector &public_value,
+                                      const bit_vector &public_in_value,
+                                      const bit_vector &public_out_value,
                                       const bit_vector &signature_public_key_hash,
                                       const std::vector<bit_vector> &signature_public_key_hash_macs,
                                       const zerocash_pour_proof<ppzksnark_ppT> &proof)
@@ -190,7 +193,8 @@ bool zerocash_pour_ppzksnark_verifier(const zerocash_pour_verification_key<ppzks
                                                                              merkle_tree_root,
                                                                              old_coin_serial_numbers,
                                                                              new_coin_commitments,
-                                                                             public_value,
+                                                                             public_in_value,
+                                                                             public_out_value,
                                                                              signature_public_key_hash,
                                                                              signature_public_key_hash_macs);
     const bool ans = r1cs_ppzksnark_verifier_strong_IC<ppzksnark_ppT>(vk.r1cs_vk, input, proof);

--- a/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.tcc
+++ b/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.tcc
@@ -168,7 +168,7 @@ zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash
                             signature_public_key_hash);
     if (!pb.is_satisfied()) {
       leave_block("Call to zerocash_pour_ppzksnark_prover");
-      throw 0;
+      throw std::invalid_argument("Constraints not satisfied by inputs");
     }
 
     zerocash_pour_proof<ppzksnark_ppT> proof = r1cs_ppzksnark_prover<ppzksnark_ppT>(pk.r1cs_pk, pb.primary_input(), pb.auxiliary_input());

--- a/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.tcc
+++ b/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.tcc
@@ -16,6 +16,7 @@
 
 #include "zerocash_pour_ppzksnark/zerocash_pour_gadget.hpp"
 #include "common/profiling.hpp"
+#include <boost/optional.hpp>
 
 namespace libzerocash {
 
@@ -129,7 +130,7 @@ zerocash_pour_keypair<ppzksnark_ppT> zerocash_pour_ppzksnark_generator(const siz
 }
 
 template<typename ppzksnark_ppT>
-zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash_pour_proving_key<ppzksnark_ppT> &pk,
+boost::optional<zerocash_pour_proof<ppzksnark_ppT>> zerocash_pour_ppzksnark_prover(const zerocash_pour_proving_key<ppzksnark_ppT> &pk,
                                                                   const std::vector<merkle_authentication_path> &old_coin_authentication_paths,
                                                                   const std::vector<size_t> &old_coin_merkle_tree_positions,
                                                                   const bit_vector &merkle_tree_root,
@@ -166,7 +167,11 @@ zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash
                             public_out_value,
                             old_coin_values,
                             signature_public_key_hash);
-    assert(pb.is_satisfied());
+    if (!pb.is_satisfied()) {
+      leave_block("Call to zerocash_pour_ppzksnark_prover");
+      return boost::none;
+    }
+
     zerocash_pour_proof<ppzksnark_ppT> proof = r1cs_ppzksnark_prover<ppzksnark_ppT>(pk.r1cs_pk, pb.primary_input(), pb.auxiliary_input());
 
     leave_block("Call to zerocash_pour_ppzksnark_prover");

--- a/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.tcc
+++ b/zerocash_pour_ppzksnark/zerocash_pour_ppzksnark.tcc
@@ -16,7 +16,6 @@
 
 #include "zerocash_pour_ppzksnark/zerocash_pour_gadget.hpp"
 #include "common/profiling.hpp"
-#include <boost/optional.hpp>
 
 namespace libzerocash {
 
@@ -130,7 +129,7 @@ zerocash_pour_keypair<ppzksnark_ppT> zerocash_pour_ppzksnark_generator(const siz
 }
 
 template<typename ppzksnark_ppT>
-boost::optional<zerocash_pour_proof<ppzksnark_ppT>> zerocash_pour_ppzksnark_prover(const zerocash_pour_proving_key<ppzksnark_ppT> &pk,
+zerocash_pour_proof<ppzksnark_ppT> zerocash_pour_ppzksnark_prover(const zerocash_pour_proving_key<ppzksnark_ppT> &pk,
                                                                   const std::vector<merkle_authentication_path> &old_coin_authentication_paths,
                                                                   const std::vector<size_t> &old_coin_merkle_tree_positions,
                                                                   const bit_vector &merkle_tree_root,
@@ -169,7 +168,7 @@ boost::optional<zerocash_pour_proof<ppzksnark_ppT>> zerocash_pour_ppzksnark_prov
                             signature_public_key_hash);
     if (!pb.is_satisfied()) {
       leave_block("Call to zerocash_pour_ppzksnark_prover");
-      return boost::none;
+      throw 0;
     }
 
     zerocash_pour_proof<ppzksnark_ppT> proof = r1cs_ppzksnark_prover<ppzksnark_ppT>(pk.r1cs_pk, pb.primary_input(), pb.auxiliary_input());


### PR DESCRIPTION
Supersedes #19.

---

:warning: **This PR makes changes to the zk-SNARK circuit and should be reviewed carefully.** :warning: 

---

As part of our Calgary redesign, we've begun an effort to merge the behavior of Protect and Pour together. The zk-SNARK circuit now accepts a `(vpub_old, vpub_new)` pair in place of the old `vpub`, and the balance equation is modified appropriately to achieve _pour symmetry_. The circuit also bypasses merkle path authentication checks for input coins which are zero-valued, achieving _variable input coin arity_. Some redundant constraints are also removed.

The API is modified slightly to introduce the concept of a `PourInput` and `PourOutput`, abstracting away the arity behaviors and simplifying the design. The old PourTransaction API is still available and tested for now, I leave this for future work to improve.
